### PR TITLE
adding thread_context handling; in case of multi-threaded client, the…

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(s3select_example s3select_example.cpp)
 target_include_directories(s3select_example PUBLIC ../include)
-target_link_libraries(s3select_example boost_date_time)
+target_link_libraries(s3select_example boost_date_time boost_system boost_thread)
 
 add_executable(generate_rand_csv generate_rand_csv.c)
 

--- a/example/s3select_example.cpp
+++ b/example/s3select_example.cpp
@@ -7,23 +7,6 @@
 using namespace s3selectEngine;
 using namespace BOOST_SPIRIT_CLASSIC_NS;
 
-int cli_get_schema(const char* input_schema, actionQ& x)
-{
-  g_push_column.set_action_q(&x);
-
-  rule<> column_name_rule = lexeme_d[(+alpha_p >> *digit_p)];
-
-  //TODO an issue to resolve with trailing space
-  parse_info<> info = parse(input_schema, ((column_name_rule)[BOOST_BIND_ACTION(push_column)] >> *(',' >> (column_name_rule)[BOOST_BIND_ACTION(push_column)])), space_p);
-
-  if (!info.full)
-  {
-    std::cout << "failure in schema description " << input_schema << std::endl;
-    return -1;
-  }
-
-  return 0;
-}
 
 int main(int argc, char** argv)
 {

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -43,7 +43,7 @@ enum class s3select_func_En_t {ADD,
                               };
 
 
-class s3select_functions : public __clt_allocator
+class s3select_functions
 {
 
 private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(s3select_test s3select_test.cpp)
 target_include_directories(s3select_test PUBLIC ../include)
-target_link_libraries(s3select_test gtest gtest_main boost_date_time)
+target_link_libraries(s3select_test gtest gtest_main boost_date_time boost_thread boost_system )
 
-
+include(GoogleTest)
 gtest_discover_tests(s3select_test)


### PR DESCRIPTION
… engine is maintaining a context per thread. upon parsing phase the correct context is set before building the AST

Signed-off-by: gal salomon <gal.salomon@gmail.com>