### PR TITLE
s3select: add trim operator , fix substring and bypass boost::spirit rescan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(s3select)
 
-set(CMAKE_CXX_FLAGS "-std=gnu++17 -ggdb")
+set(CMAKE_CXX_FLAGS "-std=gnu++17 -ggdb -Wnon-virtual-dtor -Wreorder -Wno-unused-variable")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -77,200 +77,250 @@ struct actionQ
   size_t when_than_count;
 
   actionQ():when_than_count(0), in_set_count(0){}
+
+  std::map<void*,std::vector<char*> *> x_map;
+
+  ~actionQ()
+  {
+    for(auto m : x_map)
+      delete m.second;
+  }
   
+  bool is_already_scanned(void *th,char *a)
+  {
+    //purpose: caller get indication in the case a specific builder is scan more than once the same text(pointer)
+    auto t = x_map.find(th);
+
+    if(t == x_map.end())
+    {
+      auto v = new std::vector<char*>;//TODO delete 
+      x_map.insert(std::pair<void*,std::vector<char*> *>(th,v));
+      v->push_back(a);
+    }
+    else
+    {
+      for( auto c : *(t->second) )
+      {
+        if( strcmp(c,a) == 0)
+          return true;
+      }
+      t->second->push_back(a);
+    }
+    return false;
+  }
+
 };
 
 class s3select;
 
-struct push_from_clause
+struct base_ast_builder
 {
   void operator()(s3select* self, const char* a, const char* b) const;
+
+  virtual void builder(s3select* self, const char* a, const char* b) const = 0;
+};
+
+struct push_from_clause : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_from_clause g_push_from_clause;
 
-struct push_number
+struct push_number : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_number g_push_number;
 
-struct push_float_number
+struct push_float_number : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_float_number g_push_float_number;
 
-struct push_string
+struct push_string : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_string g_push_string;
 
-struct push_variable
+struct push_variable : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_variable g_push_variable;
 
 /////////////////////////arithmetic unit  /////////////////
-struct push_addsub
+struct push_addsub : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_addsub g_push_addsub;
 
-struct push_mulop
+struct push_mulop : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_mulop g_push_mulop;
 
-struct push_addsub_binop
+struct push_addsub_binop : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_addsub_binop g_push_addsub_binop;
 
-struct push_mulldiv_binop
+struct push_mulldiv_binop : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_mulldiv_binop g_push_mulldiv_binop;
 
-struct push_function_arg
+struct push_function_arg : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_function_arg g_push_function_arg;
 
-struct push_function_name
+struct push_function_name : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_function_name g_push_function_name;
 
-struct push_function_expr
+struct push_function_expr : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_function_expr g_push_function_expr;
 
-struct push_cast_expr
+struct push_cast_expr : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_cast_expr g_push_cast_expr;
 
-struct push_data_type
+struct push_data_type : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_data_type g_push_data_type;
 
 ////////////////////// logical unit ////////////////////////
 
-struct push_compare_operator
+struct push_compare_operator : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 
 };
 static push_compare_operator g_push_compare_operator;
 
-struct push_logical_operator
+struct push_logical_operator : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 
 };
 static push_logical_operator g_push_logical_operator;
 
-struct push_arithmetic_predicate
+struct push_arithmetic_predicate : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 
 };
 static push_arithmetic_predicate g_push_arithmetic_predicate;
 
-struct push_logical_predicate
+struct push_logical_predicate : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_logical_predicate g_push_logical_predicate;
 
-struct push_negation
+struct push_negation : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_negation g_push_negation;
 
-struct push_column_pos
+struct push_column_pos : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static  push_column_pos g_push_column_pos;
 
-struct push_projection
+struct push_projection : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_projection g_push_projection;
 
-struct push_alias_projection
+struct push_alias_projection : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_alias_projection g_push_alias_projection;
 
-struct push_between_filter
+struct push_between_filter : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_between_filter g_push_between_filter;
 
-struct push_in_predicate
+struct push_in_predicate : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_in_predicate g_push_in_predicate;
 
-struct push_in_predicate_counter
+struct push_in_predicate_counter : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_in_predicate_counter g_push_in_predicate_counter;
 
-struct push_in_predicate_counter_start
+struct push_in_predicate_counter_start : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_in_predicate_counter_start g_push_in_predicate_counter_start;
 
-struct push_like_predicate
+struct push_like_predicate : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_like_predicate g_push_like_predicate;
 
-struct push_is_null_predicate
+struct push_is_null_predicate : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_is_null_predicate g_push_is_null_predicate;
 
-struct push_case_when_else
+struct push_case_when_else : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_case_when_else g_push_case_when_else;
 
-struct push_when_than
+struct push_when_than : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_when_than g_push_when_than;
 
-struct push_debug_1
+struct push_substr_from : public base_ast_builder
 {
-  void operator()(s3select* self, const char* a, const char* b) const;
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_substr_from g_push_substr_from;
+
+struct push_substr_from_for : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_substr_from_for g_push_substr_from_for;
+
+struct push_debug_1 : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
 };
 static push_debug_1 g_push_debug_1;
 
@@ -546,14 +596,24 @@ public:
   };
 };
 
-void push_from_clause::operator()(s3select* self, const char* a, const char* b) const
+void base_ast_builder::operator()(s3select *self, const char *a, const char *b) const
+{
+  //the purpose of the following procedure is to bypass boost::spirit rescan (calling to bind-action more than once per the same text)
+  //which cause wrong AST creation (and later false execution).
+  if (self->getAction()->is_already_scanned((void *)(this), const_cast<char *>(a)))
+    return;
+
+  builder(self, a, b);
+}
+
+void push_from_clause::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
   self->getAction()->from_clause = token;
 }
 
-void push_number::operator()(s3select* self, const char* a, const char* b) const
+void push_number::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -562,7 +622,7 @@ void push_number::operator()(s3select* self, const char* a, const char* b) const
   self->getAction()->exprQ.push_back(v);
 }
 
-void push_float_number::operator()(s3select* self, const char* a, const char* b) const
+void push_float_number::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -585,7 +645,7 @@ void push_float_number::operator()(s3select* self, const char* a, const char* b)
   }
 }
 
-void push_string::operator()(s3select* self, const char* a, const char* b) const
+void push_string::builder(s3select* self, const char* a, const char* b) const
 {
   a++;
   b--; // remove double quotes
@@ -596,7 +656,7 @@ void push_string::operator()(s3select* self, const char* a, const char* b) const
   self->getAction()->exprQ.push_back(v);
 }
 
-void push_variable::operator()(s3select* self, const char* a, const char* b) const
+void push_variable::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -626,7 +686,7 @@ void push_variable::operator()(s3select* self, const char* a, const char* b) con
   self->getAction()->exprQ.push_back(v);
 }
 
-void push_addsub::operator()(s3select* self, const char* a, const char* b) const
+void push_addsub::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -640,7 +700,7 @@ void push_addsub::operator()(s3select* self, const char* a, const char* b) const
   }
 }
 
-void push_mulop::operator()(s3select* self, const char* a, const char* b) const
+void push_mulop::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -662,7 +722,7 @@ void push_mulop::operator()(s3select* self, const char* a, const char* b) const
   }
 }
 
-void push_addsub_binop::operator()(s3select* self, const char* a, const char* b) const
+void push_addsub_binop::builder(s3select* self, const char* a, const char* b) const
 {
   base_statement* l = 0, *r = 0;
 
@@ -676,7 +736,7 @@ void push_addsub_binop::operator()(s3select* self, const char* a, const char* b)
   self->getAction()->exprQ.push_back(as);
 }
 
-void push_mulldiv_binop::operator()(s3select* self, const char* a, const char* b) const
+void push_mulldiv_binop::builder(s3select* self, const char* a, const char* b) const
 {
   base_statement* vl = 0, *vr = 0;
 
@@ -690,7 +750,7 @@ void push_mulldiv_binop::operator()(s3select* self, const char* a, const char* b
   self->getAction()->exprQ.push_back(f);
 }
 
-void push_function_arg::operator()(s3select* self, const char* a, const char* b) const
+void push_function_arg::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -704,7 +764,7 @@ void push_function_arg::operator()(s3select* self, const char* a, const char* b)
   }
 }
 
-void push_function_name::operator()(s3select* self, const char* a, const char* b) const
+void push_function_name::builder(s3select* self, const char* a, const char* b) const
 {
   b--;
   while (*b == '(' || *b == ' ')
@@ -719,7 +779,7 @@ void push_function_name::operator()(s3select* self, const char* a, const char* b
   self->getAction()->funcQ.push_back(func);
 }
 
-void push_function_expr::operator()(s3select* self, const char* a, const char* b) const
+void push_function_expr::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -729,7 +789,7 @@ void push_function_expr::operator()(s3select* self, const char* a, const char* b
   self->getAction()->exprQ.push_back(func);
 }
 
-void push_compare_operator::operator()(s3select* self, const char* a, const char* b) const
+void push_compare_operator::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
   arithmetic_operand::cmp_t c = arithmetic_operand::cmp_t::NA;
@@ -766,7 +826,7 @@ void push_compare_operator::operator()(s3select* self, const char* a, const char
   self->getAction()->arithmetic_compareQ.push_back(c);
 }
 
-void push_logical_operator::operator()(s3select* self, const char* a, const char* b) const
+void push_logical_operator::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
   logical_operand::oplog_t l = logical_operand::oplog_t::NA;
@@ -787,7 +847,7 @@ void push_logical_operator::operator()(s3select* self, const char* a, const char
   self->getAction()->logical_compareQ.push_back(l);
 }
 
-void push_arithmetic_predicate::operator()(s3select* self, const char* a, const char* b) const
+void push_arithmetic_predicate::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -804,7 +864,7 @@ void push_arithmetic_predicate::operator()(s3select* self, const char* a, const 
   self->getAction()->condQ.push_back(t);
 }
 
-void push_logical_predicate::operator()(s3select* self, const char* a, const char* b) const
+void push_logical_predicate::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -828,7 +888,7 @@ void push_logical_predicate::operator()(s3select* self, const char* a, const cha
   self->getAction()->condQ.push_back(f);
 }
 
-void push_negation::operator()(s3select* self, const char* a, const char* b) const
+void push_negation::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
   base_statement* pred;
@@ -855,7 +915,7 @@ void push_negation::operator()(s3select* self, const char* a, const char* b) con
   }
 }
 
-void push_column_pos::operator()(s3select* self, const char* a, const char* b) const
+void push_column_pos::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
   variable* v;
@@ -872,7 +932,7 @@ void push_column_pos::operator()(s3select* self, const char* a, const char* b) c
   self->getAction()->exprQ.push_back(v);
 }
 
-void push_projection::operator()(s3select* self, const char* a, const char* b) const
+void push_projection::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -880,7 +940,7 @@ void push_projection::operator()(s3select* self, const char* a, const char* b) c
   self->getAction()->exprQ.pop_back();
 }
 
-void push_alias_projection::operator()(s3select* self, const char* a, const char* b) const
+void push_alias_projection::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
   //extract alias name
@@ -901,7 +961,7 @@ void push_alias_projection::operator()(s3select* self, const char* a, const char
   self->getAction()->exprQ.pop_back();
 }
 
-void push_between_filter::operator()(s3select* self, const char* a, const char* b) const
+void push_between_filter::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -924,7 +984,7 @@ void push_between_filter::operator()(s3select* self, const char* a, const char* 
   self->getAction()->condQ.push_back(func);
 }
 
-void push_in_predicate_counter::operator()(s3select* self, const char* a, const char* b) const
+void push_in_predicate_counter::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -932,7 +992,7 @@ void push_in_predicate_counter::operator()(s3select* self, const char* a, const 
 
 }
 
-void push_in_predicate_counter_start::operator()(s3select* self, const char* a, const char* b) const
+void push_in_predicate_counter_start::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -940,7 +1000,7 @@ void push_in_predicate_counter_start::operator()(s3select* self, const char* a, 
 
 }
 
-void push_in_predicate::operator()(s3select* self, const char* a, const char* b) const
+void push_in_predicate::builder(s3select* self, const char* a, const char* b) const
 {
   // expr in (e1,e2,e3 ...)
   std::string token(a, b);
@@ -963,7 +1023,7 @@ void push_in_predicate::operator()(s3select* self, const char* a, const char* b)
   self->getAction()->condQ.push_back(func);
 }
 
-void push_like_predicate::operator()(s3select* self, const char* a, const char* b) const
+void push_like_predicate::builder(s3select* self, const char* a, const char* b) const
 {
   // expr like expr ; both should be string, the second expression could be compiled at the
   // time AST is build, which will improve performance much.
@@ -993,7 +1053,7 @@ void push_like_predicate::operator()(s3select* self, const char* a, const char* 
   self->getAction()->condQ.push_back(func);
 }
 
-void push_is_null_predicate::operator()(s3select* self, const char* a, const char* b) const
+void push_is_null_predicate::builder(s3select* self, const char* a, const char* b) const
 {
     //expression is null 
   std::string token(a, b);
@@ -1009,7 +1069,7 @@ void push_is_null_predicate::operator()(s3select* self, const char* a, const cha
   self->getAction()->condQ.push_back(func);
 }
 
-void push_when_than::operator()(s3select* self, const char* a, const char* b) const
+void push_when_than::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -1029,7 +1089,7 @@ void push_when_than::operator()(s3select* self, const char* a, const char* b) co
  self->getAction()->when_than_count ++;
 }
 
-void push_case_when_else::operator()(s3select* self, const char* a, const char* b) const
+void push_case_when_else::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -1060,7 +1120,7 @@ void push_case_when_else::operator()(s3select* self, const char* a, const char* 
   self->getAction()->exprQ.push_back(func);
 }
 
-void push_cast_expr::operator()(s3select* self, const char* a, const char* b) const
+void push_cast_expr::builder(s3select* self, const char* a, const char* b) const
 {
   //cast(expression as int/float/string/timestamp) --> new function "int/float/string/timestamp" ( args = expression )
   std::string token(a, b);
@@ -1079,7 +1139,7 @@ void push_cast_expr::operator()(s3select* self, const char* a, const char* b) co
   self->getAction()->exprQ.push_back(func);
 }
 
-void push_data_type::operator()(s3select* self, const char* a, const char* b) const
+void push_data_type::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
@@ -1100,7 +1160,45 @@ void push_data_type::operator()(s3select* self, const char* a, const char* b) co
   }
 }
 
-void push_debug_1::operator()(s3select* self, const char* a, const char* b) const
+void push_substr_from::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  __function* func = S3SELECT_NEW(self, __function, "#substring_from#", self->getS3F());
+
+  base_statement* expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(expr);
+
+  base_statement* start_position = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(start_position);
+
+  self->getAction()->exprQ.push_back(func);
+}  
+
+void push_substr_from_for::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  __function* func = S3SELECT_NEW(self, __function, "#substring_from#", self->getS3F());
+
+  base_statement* expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(expr);
+
+  base_statement* start_position = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(start_position);
+
+  base_statement* end_position = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(end_position);
+
+  self->getAction()->exprQ.push_back(func);
+}  
+
+void push_debug_1::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 }

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -68,6 +68,7 @@ struct actionQ
   std::vector<base_statement*> condQ;
   std::vector<base_statement*> whenThenQ;
   std::vector<std::string> dataTypeQ;
+  std::vector<std::string> trimTypeQ;
   projection_alias alias_map;
   std::string from_clause;
   std::vector<std::string> schema_columns;
@@ -324,6 +325,30 @@ struct push_debug_1 : public base_ast_builder
 };
 static push_debug_1 g_push_debug_1;
 
+struct push_trim_type : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_trim_type g_push_trim_type; 
+
+struct push_trim_whitespace_both : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_trim_whitespace_both g_push_trim_whitespace_both;
+
+struct push_trim_expr_one_side_whitespace : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_trim_expr_one_side_whitespace g_push_trim_expr_one_side_whitespace;
+
+struct push_trim_expr_anychar_anyside : public base_ast_builder
+{
+  void builder(s3select* self, const char* a, const char* b) const;
+};
+static push_trim_expr_anychar_anyside g_push_trim_expr_anychar_anyside;
+
 struct s3select : public bsc::grammar<s3select>
 {
 private:
@@ -555,7 +580,7 @@ public:
 
       arithmetic_argument = (float_number)[BOOST_BIND_ACTION(push_float_number)] |  (number)[BOOST_BIND_ACTION(push_number)] | (column_pos)[BOOST_BIND_ACTION(push_column_pos)] |
                             (string)[BOOST_BIND_ACTION(push_string)] |
-                            (cast) | (substr) |
+                            (cast) | (substr) | (trim) |
                             (function) | (variable)[BOOST_BIND_ACTION(push_variable)] ;//function is pushed by right-term
 
       cast = (bsc::str_p("cast") >> '(' >> arithmetic_expression >> bsc::str_p("as") >> (data_type)[BOOST_BIND_ACTION(push_data_type)] >> ')') [BOOST_BIND_ACTION(push_cast_expr)];
@@ -567,6 +592,18 @@ public:
       substr_from = (bsc::str_p("substring") >> '(' >> (arithmetic_expression >> bsc::str_p("from") >> arithmetic_expression) >> ')') [BOOST_BIND_ACTION(push_substr_from)];
 
       substr_from_for = (bsc::str_p("substring") >> '(' >> (arithmetic_expression >> bsc::str_p("from") >> arithmetic_expression >> bsc::str_p("for") >> arithmetic_expression) >> ')') [BOOST_BIND_ACTION(push_substr_from_for)];
+      
+      trim = (trim_whitespace_both) | (trim_one_side_whitespace) | (trim_anychar_anyside);
+
+      trim_one_side_whitespace = (bsc::str_p("trim") >> '(' >> (trim_type)[BOOST_BIND_ACTION(push_trim_type)] >> arithmetic_expression >> ')') [BOOST_BIND_ACTION(push_trim_expr_one_side_whitespace)];
+
+      trim_whitespace_both = (bsc::str_p("trim") >> '(' >> arithmetic_expression >> ')') [BOOST_BIND_ACTION(push_trim_whitespace_both)];
+
+      trim_anychar_anyside = (bsc::str_p("trim") >> '(' >> ((trim_remove_type)[BOOST_BIND_ACTION(push_trim_type)] >> arithmetic_expression >> bsc::str_p("from") >> arithmetic_expression)  >> ')') [BOOST_BIND_ACTION(push_trim_expr_anychar_anyside)];
+      
+      trim_type = ((bsc::str_p("leading") >> bsc::str_p("from")) | ( bsc::str_p("trailing") >> bsc::str_p("from")) | (bsc::str_p("both") >> bsc::str_p("from")) | bsc::str_p("from") ); 
+
+      trim_remove_type = (bsc::str_p("leading") | bsc::str_p("trailing") | bsc::str_p("both") );
 
       number = bsc::int_p;
 
@@ -589,7 +626,7 @@ public:
     }
 
 
-    bsc::rule<ScannerT> cast, data_type, variable, select_expr, s3_object, where_clause, number, float_number, string, arith_cmp, log_op, condition_expression, binary_condition, arithmetic_predicate, factor, substr, substr_from, substr_from_for;
+    bsc::rule<ScannerT> cast, data_type, variable, trim_type, trim_remove_type, select_expr, s3_object, where_clause, number, float_number, string, arith_cmp, log_op, condition_expression, binary_condition, arithmetic_predicate, factor, trim, trim_whitespace_both, trim_one_side_whitespace, trim_anychar_anyside, substr, substr_from, substr_from_for;
     bsc::rule<ScannerT> special_predicates,between_predicate, in_predicate, like_predicate, is_null, is_not_null;
     bsc::rule<ScannerT> muldiv_operator, addsubop_operator, function, arithmetic_expression, addsub_operand, list_of_function_arguments, arithmetic_argument, mulldiv_operand;
     bsc::rule<ScannerT> fs_type, object_path;
@@ -1166,6 +1203,77 @@ void push_data_type::builder(s3select* self, const char* a, const char* b) const
   }
 }
 
+void push_trim_whitespace_both::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  __function* func = S3SELECT_NEW(self, __function, "#trim#", self->getS3F());
+
+  base_statement* expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(expr);
+
+  self->getAction()->exprQ.push_back(func);
+}  
+
+void push_trim_expr_one_side_whitespace::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  std::string trim_function;
+
+  trim_function = self->getAction()->trimTypeQ.back();
+  self->getAction()->trimTypeQ.pop_back(); 
+
+  __function* func = S3SELECT_NEW(self, __function, trim_function.c_str(), self->getS3F());
+
+  base_statement* inp_expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(inp_expr);
+
+  self->getAction()->exprQ.push_back(func);
+} 
+
+void push_trim_expr_anychar_anyside::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  std::string trim_function;
+
+  trim_function = self->getAction()->trimTypeQ.back();
+  self->getAction()->trimTypeQ.pop_back(); 
+
+  __function* func = S3SELECT_NEW(self, __function, trim_function.c_str(), self->getS3F());
+
+  base_statement* expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(expr);
+
+  base_statement* inp_expr = self->getAction()->exprQ.back();
+  self->getAction()->exprQ.pop_back();
+  func->push_argument(inp_expr);
+
+  self->getAction()->exprQ.push_back(func);
+} 
+
+void push_trim_type::builder(s3select* self, const char* a, const char* b) const
+{
+  std::string token(a, b);
+
+  auto trim_option = [&](const char *s){return strncmp(a,s,strlen(s))==0;};
+
+  if(trim_option("leading"))
+  {
+    self->getAction()->trimTypeQ.push_back("#leading#");
+  }else if(trim_option("trailing"))
+  {
+    self->getAction()->trimTypeQ.push_back("#trailing#");
+  }else 
+  {
+    self->getAction()->trimTypeQ.push_back("#trim#");
+  }
+} 
+
 void push_substr_from::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
@@ -1198,7 +1306,7 @@ void push_substr_from_for::builder(s3select* self, const char* a, const char* b)
 
   base_statement* end_position = self->getAction()->exprQ.back();
   self->getAction()->exprQ.pop_back();
-  
+
   func->push_argument(end_position);
   func->push_argument(start_position);
   func->push_argument(expr);

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -1546,7 +1546,7 @@ TEST(TestS3selectFunctions, case_when_than_else)
 TEST(TestS3selectFunctions, substr11)
 {
     s3select s3select_syntax;
-    const std::string input_query = "select substr(\"01234567890\",2*0+1,1.53*0+3) from stdin ;" ;
+    const std::string input_query = "select substring(\"01234567890\",2*0+1,1.53*0+3) from stdin ;" ;
     auto status = s3select_syntax.parse_query(input_query.c_str());
     ASSERT_EQ(status, 0);
     s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
@@ -1566,7 +1566,7 @@ TEST(TestS3selectFunctions, substr11)
 TEST(TestS3selectFunctions, substr12)
 {
     s3select s3select_syntax;
-    const std::string input_query = "select substr(\"01234567890\",2*0+1,1+2.0) from stdin ;" ;
+    const std::string input_query = "select substring(\"01234567890\",2*0+1,1+2.0) from stdin ;" ;
     auto status = s3select_syntax.parse_query(input_query.c_str());
     ASSERT_EQ(status, 0);
     s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
@@ -1586,7 +1586,7 @@ TEST(TestS3selectFunctions, substr12)
 TEST(TestS3selectFunctions, substr13)
 {
     s3select s3select_syntax;
-    const std::string input_query = "select substr(\"01234567890\",2.5*2+1,1+2) from stdin ;" ;
+    const std::string input_query = "select substring(\"01234567890\",2.5*2+1,1+2) from stdin ;" ;
     auto status = s3select_syntax.parse_query(input_query.c_str());
     ASSERT_EQ(status, 0);
     s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
@@ -1601,6 +1601,207 @@ TEST(TestS3selectFunctions, substr13)
         ); 
     ASSERT_EQ(status, 0); 
     ASSERT_EQ(s3select_result, std::string("567,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr14)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\",0) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr15)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\",-4) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr16)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\",0,100) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr17)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"12345\",0,5) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("1234,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr18)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"12345\",-1,5) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr19)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\" from 0) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr20)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\" from -4) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr21)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(\"123456789\" from 0 for 100) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("123456789,\n"));
+} 
+
+TEST(TestS3selectFunctions, substr22)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select \"true\" from stdin where 5 == cast(substring(\"523\",1,1) as int);" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("true,\n"));
+} 
+
+
+TEST(TestS3selectFunctions, substr23)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select \"true\" from stdin where cast(substring(\"523\",1,1) as int) > cast(substring(\"123\",1,1) as int)  ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("true,\n"));
 } 
 
 TEST(TestS3selectFunctions, coalesce)
@@ -1808,7 +2009,7 @@ TEST(TestS3selectFunctions, caststring2)
 TEST(TestS3selectFunctions, castsubstr)
 {
     s3select s3select_syntax;
-    const std::string input_query = "select substr(cast(cast(\"1234567\" as int) as string),2,2) from stdin ;" ;
+    const std::string input_query = "select substring(cast(cast(\"1234567\" as int) as string),2,2) from stdin ;" ;
     auto status = s3select_syntax.parse_query(input_query.c_str());
     ASSERT_EQ(status, 0);
     s3selectEngine::csv_object s3_csv_object(&s3select_syntax);

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -22,7 +22,7 @@ std::string run_expression_in_C_prog(const char* expression)
   //contain return result
   char result_buff[100];
 
-  char* prog_c;
+  char* prog_c = 0;
 
   if(fp_c_file)
   {
@@ -45,6 +45,9 @@ std::string run_expression_in_C_prog(const char* expression)
 
   if(!fp_build)
   {
+    if(prog_c)
+	free(prog_c);
+
     return std::string("#ERROR#");
   }
 
@@ -52,6 +55,10 @@ std::string run_expression_in_C_prog(const char* expression)
 
   unlink(c_run_file.c_str());
   unlink(c_test_file.c_str());
+  fclose(fp_build);
+
+  if(prog_c)
+    free(prog_c);
 
   return std::string(result_buff);
 }

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -2086,6 +2086,266 @@ TEST(TestS3selectFunctions, castdatediff)
     ASSERT_EQ(s3select_result, std::string("10,\n"));
 } 
 
+TEST(TestS3selectFunctions, trim)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(\"   \twelcome\t   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("\twelcome\t,\n"));
+}
+
+TEST(TestS3selectFunctions, trim1)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(\"   foobar   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+} 
+
+TEST(TestS3selectFunctions, trim2)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(trailing from \"   foobar   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("   foobar,\n"));
+}
+
+TEST(TestS3selectFunctions, trim3)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(leading from \"   foobar   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar   ,\n"));
+}
+
+TEST(TestS3selectFunctions, trim4)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(both from \"   foobar   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+} 
+
+TEST(TestS3selectFunctions, trim5)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(from \"   foobar   \") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+} 
+
+TEST(TestS3selectFunctions, trim6)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(both \"12\" from  \"1112211foobar22211122\") from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+}
+
+TEST(TestS3selectFunctions, trim7)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(trim(both from '   foobar   '),2,3) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("oob,\n"));
+} 
+
+TEST(TestS3selectFunctions, trim8)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select substring(trim(both '12' from '1112211foobar22211122'),1,6) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+} 
+
+TEST(TestS3selectFunctions, trim9)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select cast(trim(both \"12\" from \"111221134567822211122\") as int) + 5 from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("345683,\n"));
+}
+
+TEST(TestS3selectFunctions, trimefalse)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select cast(trim(both from \"12\" \"111221134567822211122\") as int) + 5 from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_NE(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_NE(status, 0); 
+    ASSERT_EQ(s3select_result, std::string(""));
+}
+
+TEST(TestS3selectFunctions, trim10)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(trim(leading from \"   foobar   \")) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+}
+
+TEST(TestS3selectFunctions, trim11)
+{
+    s3select s3select_syntax;
+    const std::string input_query = "select trim(trailing from trim(leading from \"   foobar   \")) from stdin ;" ;
+    auto status = s3select_syntax.parse_query(input_query.c_str());
+    ASSERT_EQ(status, 0);
+    s3selectEngine::csv_object s3_csv_object(&s3select_syntax);
+    std::string s3select_result;
+    std::string input;
+    size_t size = 1;
+    generate_csv(input, size);
+    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(), 
+        false, // dont skip first line 
+        false, // dont skip last line
+        true   // aggregate call
+        ); 
+    ASSERT_EQ(status, 0); 
+    ASSERT_EQ(s3select_result, std::string("foobar,\n"));
+}
+
 
 
 


### PR DESCRIPTION
Align ceph s3select with aws.

Signed-off-by: Albin Antony <aantony@redhat.com>