### PR TITLE
support ubuntu16 builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,7 +24,7 @@ jobs:
       run: sudo apt-get install -y libgtest-dev
       
     - name: install-gtest
-      run: cd /usr/src/gtest && sudo cmake . && sudo cmake --build . --target install
+      run: cd /usr/src/gtest && sudo cmake . && sudo make && sudo cp lib/*.a /usr/lib
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(s3select_test s3select_test.cpp)
 target_include_directories(s3select_test PUBLIC ../include)
-target_link_libraries(s3select_test gtest gtest_main boost_date_time boost_thread boost_system)
+target_link_libraries(s3select_test gtest gtest_main boost_date_time boost_thread boost_system pthread)
 
 include(GoogleTest)
 gtest_discover_tests(s3select_test)


### PR DESCRIPTION
currently failing with: "make: *** No rule to make target 'install'.
Stop"

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>