### PR TITLE
add clang-tidy github actions

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,45 @@
+name: clang-tidy
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: install-clang-tidy
+      run: sudo apt-get install -y clang-tidy
+    
+    - name: install-boost
+      run: sudo apt-get install -y libboost-all-dev
+
+    - name: fetch-gtest
+      run: sudo apt-get install -y libgtest-dev
+      
+    - name: install-gtest
+      run: cd /usr/src/gtest && sudo cmake . && sudo make && sudo cp lib/*.a /usr/lib
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: run-clang-tidy
+      run: clang-tidy -p ${{github.workspace}}/build -header-filter=.* -checks=-*,clang-analyzer-*,concurrency-*,cert-*,-cert-err58-cpp,google-explicit-constructor,misc-redundant-expression,readability-braces-around-statements.ShortStatementLines=1,readability-delete-null-pointer,readability-make-member-function-const,cppcoreguidelines-special-member-functions  example/s3select_example.cpp
+


### PR DESCRIPTION
in the next round (after cleaning up the existing warnings) we should add the following checks:
```
hicpp-exception-baseclass
misc-definitions-in-headers
cppcoreguidelines-explicit-virtual-functions
```

we may want to consider adding the following checks:
```
cppcoreguidelines-no-malloc
cppcoreguidelines-pro-type-cstyle-cast
modernize-*
```

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>