### PR TITLE
improve selection output serialization

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -1816,17 +1816,18 @@ public:
     {
       do
       {
-
         number_of_tokens = getNextRow();
         if (number_of_tokens < 0) //end of stream
         {
           if (m_is_to_aggregate)
-            for (auto& i : m_projections)
+            for (auto iter = m_projections.begin(); iter != m_projections.end(); iter++)
             {
-              i->set_last_call();
-              i->set_skip_non_aggregate(false);//projection column is set to be runnable
-              result.append( i->eval().to_string() );
-              result.append(",");
+              (*iter)->set_last_call();
+              (*iter)->set_skip_non_aggregate(false);//projection column is set to be runnable
+              result.append( (*iter)->eval().to_string() );
+              if ( iter != m_projections.end() - 1 ) {
+                result.append(1u, m_csv_defintion.column_delimiter);
+              }
             }
 
           return number_of_tokens;
@@ -1838,7 +1839,7 @@ public:
           throw base_s3select_exception("on aggregation query , can not stream row data post do-aggregate call", base_s3select_exception::s3select_exp_en_t::FATAL);
         }
 
-        m_sa->update(m_row_tokens, number_of_tokens);
+        m_sa->update(m_row_tokens, number_of_tokens, m_csv_defintion.column_delimiter);
         for (auto& a : *m_s3_select->get_aliases()->get())
         {
           a.second->invalidate_cache_result();
@@ -1865,7 +1866,7 @@ public:
           return number_of_tokens;
         }
 
-        m_sa->update(m_row_tokens, number_of_tokens);
+        m_sa->update(m_row_tokens, number_of_tokens, m_csv_defintion.column_delimiter);
         for (auto& a : *m_s3_select->get_aliases()->get())
         {
           a.second->invalidate_cache_result();
@@ -1874,12 +1875,14 @@ public:
       }
       while (m_where_clause && !m_where_clause->eval().is_true());
 
-      for (auto& i : m_projections)
+      for (auto iter = m_projections.begin(); iter != m_projections.end(); iter++)
       {
-        result.append( i->eval().to_string() );
-        result.append(",");
+        result.append( (*iter)->eval().to_string() );
+        if ( iter != m_projections.end() - 1 ) {
+          result.append(1u, m_csv_defintion.column_delimiter);
+        }
       }
-      result.append("\n");
+      result.append(1u, m_csv_defintion.row_delimiter);
     }
 
     return number_of_tokens; //TODO wrong

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -232,7 +232,7 @@ public:
   {
     std::copy_n(tokens.begin(), num_of_tokens, m_columns.begin());
     m_upper_bound = num_of_tokens;
-	m_column_delimiter = column_delimiter;
+    m_column_delimiter = column_delimiter;
   }
 
   int get_column_pos(const char* n)

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -217,6 +217,7 @@ class scratch_area
 private:
   std::vector<std::string_view> m_columns{128};
   int m_upper_bound;
+  char m_column_delimiter;
 
   std::vector<std::pair<std::string, int >> m_column_name_pos;
 
@@ -227,10 +228,11 @@ public:
     m_column_name_pos.push_back( std::pair<const char*, int>(n, pos));
   }
 
-  void update(std::vector<char*>& tokens, size_t num_of_tokens)
+  void update(std::vector<char*>& tokens, size_t num_of_tokens, char& column_delimiter)
   {
     std::copy_n(tokens.begin(), num_of_tokens, m_columns.begin());
     m_upper_bound = num_of_tokens;
+	m_column_delimiter = column_delimiter;
   }
 
   int get_column_pos(const char* n)
@@ -261,6 +263,11 @@ public:
   int get_num_of_columns()
   {
     return m_upper_bound;
+  }
+  
+  char get_column_delimiter()
+  {
+    return m_column_delimiter;
   }
 };
 
@@ -1306,6 +1313,7 @@ public:
     int i;
     size_t pos=0;
     int num_of_columns = m_scratch->get_num_of_columns();
+    char column_delimiter = m_scratch->get_column_delimiter();
     for(i=0; i<num_of_columns-1; i++)
     {
       size_t len = m_scratch->get_column_value(i).size();
@@ -1316,7 +1324,7 @@ public:
 
       memcpy(&m_star_op_result_charc[pos], m_scratch->get_column_value(i).data(), len);
       pos += len;
-      m_star_op_result_charc[ pos ] = ',';//TODO need for another abstraction (per file type)
+      m_star_op_result_charc[ pos ] = column_delimiter;
       pos ++;
 
     }


### PR DESCRIPTION
1. column delimiter of output serialization is consistent with input
2. del superfluous char like "," in output row end

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>