### PR TITLE
- JSON processing : fix the initialization of scratch-area per row processing

### DIFF
--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -570,7 +570,20 @@ struct _fn_count : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
-    count += 1;
+    if (args->size())
+    {// in case argument exist, should count only non-null.
+      auto iter = args->begin();
+      base_statement* x = *iter;
+
+      if(!x->eval().is_null())
+      {
+	count += 1;
+      }
+    }
+    else
+    {//in case of non-arguments // count()
+	count += 1;
+    }
 
     return true;
   }

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1081,7 +1081,7 @@ private:
   bool parquet_type;
   char str_buff[4096];
   uint16_t buff_loc;
-
+  int max_json_idx;
 
 public:
 
@@ -1089,7 +1089,7 @@ public:
   typedef std::vector< json_key_value_t > json_star_op_cont_t;
   json_star_op_cont_t m_json_star_operation;
 
-  scratch_area():m_upper_bound(-1),parquet_type(false),buff_loc(0)
+  scratch_area():m_upper_bound(-1),parquet_type(false),buff_loc(0),max_json_idx(-1)
   {//TODO it should resize dynamicly
     m_schema_values = new std::vector<value>(128,value(""));
   }
@@ -1107,7 +1107,10 @@ public:
   void clear_data()
   {
     m_json_star_operation.clear();
-    (*m_schema_values).clear();
+    for(int i=0;i<=max_json_idx;i++)
+    {
+      (*m_schema_values)[i].setnull();
+    }
   } 
 
   void set_column_pos(const char* n, int pos)//TODO use std::string
@@ -1201,6 +1204,10 @@ public:
 
   int update_json_varible(value v,int json_idx)
   {
+    if(json_idx>max_json_idx)
+    {
+      max_json_idx = json_idx;
+    }
     (*m_schema_values)[ json_idx ] = v;
     return 0;
   }

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -477,6 +477,9 @@ public:
     __val.str = m_str_value.data();
   }
 
+  explicit value(std::nullptr_t) : type(value_En_t::S3NULL)
+  {}
+
   ~value()
   {//TODO should be a part of the cleanup routine(__function::push_for_cleanup)
     multiple_values.values.clear();
@@ -1091,7 +1094,7 @@ public:
 
   scratch_area():m_upper_bound(-1),parquet_type(false),buff_loc(0),max_json_idx(-1)
   {//TODO it should resize dynamicly
-    m_schema_values = new std::vector<value>(128,value(""));
+    m_schema_values = new std::vector<value>(128,value(nullptr));
   }
 
   ~scratch_area()


### PR DESCRIPTION
- fix for count operator, it count also NULL values.

Signed-off-by: gal salomon <gal.salomon@gmail.com>