### PR TITLE
performance improvements in scratch-area

### DIFF
--- a/example/s3select_example.cpp
+++ b/example/s3select_example.cpp
@@ -458,7 +458,6 @@ int run_on_localFile(char* input_query)
   std::string s3select_result;
   s3selectEngine::csv_object::csv_defintions csv;
   csv.use_header_info = false;
-  bool do_aggregate = false;
   //csv.column_delimiter='|';
   //csv.row_delimiter='\t';
 
@@ -476,28 +475,9 @@ int run_on_localFile(char* input_query)
   char* buff = (char*)malloc( BUFF_SIZE );
   while(1)
   {
-    //char buff[4096];
-
-    //char * in = fgets(buff,sizeof(buff),fp);
     size_t input_sz = fread(buff, 1, BUFF_SIZE, fp);
     char* in=buff;
-    //input_sz = strlen(buff);
-    //size_t input_sz = in == 0 ? 0 : strlen(in);
-
-    if (!input_sz || feof(fp)) 
-    {
-        do_aggregate = true;
-    }
-
-    int status;
-    if(do_aggregate == true)
-    {
-      status = s3_csv_object.run_s3select_on_object(s3select_result, in, input_sz, false, false, do_aggregate);
-    }
-    else
-    {
-      status = s3_csv_object.run_s3select_on_stream(s3select_result, in, input_sz, statbuf.st_size);
-    }
+    status = s3_csv_object.run_s3select_on_stream(s3select_result, in, input_sz, statbuf.st_size);
 
     if(status<0)
     {


### PR DESCRIPTION
- a unification of different flows per each data-source
- in the case of string type, no need to copy
- bug fix for the example application
- the improvement in scratch-area is mainly per string type, the main impact is on CSV execution since all of its types are strings.

Signed-off-by: gal salomon <gal.salomon@gmail.com>