### PR TITLE
Star operation performance improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ if(Arrow_FOUND)
   add_definitions(-D_ARROW_EXIST)
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=gnu++17 -ggdb -Wnon-virtual-dtor -Wreorder -Wunused-variable -Wtype-limits -Wsign-compare -Wmaybe-uninitialized -O3")
+if(DEFINED ENV{DEBUG})
+  set(CMAKE_CXX_FLAGS "-std=gnu++17 -ggdb -Wnon-virtual-dtor -Wreorder -Wunused-variable -Wtype-limits -Wsign-compare -Wmaybe-uninitialized")
+else()
+  set(CMAKE_CXX_FLAGS "-std=gnu++17 -ggdb -Wnon-virtual-dtor -Wreorder -Wunused-variable -Wtype-limits -Wsign-compare -Wmaybe-uninitialized -O3")
+endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -915,11 +915,10 @@ TEST(TestS3SElect, from_stdin)
     std::string input;
     size_t size = 128;
     generate_csv(input, size);
-    status = s3_csv_object.run_s3select_on_object(s3select_result, input.c_str(), input.size(),
-        false, // dont skip first line 
-        false, // dont skip last line
-        true   // aggregate call
-        ); 
+    std::string input_copy = input;
+    s3select_result = run_s3select(input_query,input);
+
+    ASSERT_EQ(input_copy, s3select_result);
     ASSERT_EQ(status, 0);
 }
 


### PR DESCRIPTION
- in the case of star-operation (CSV and Parquet) each column was converted to-string and copied. the refactor star-operation not converting, and not copying, instead a reference to value is being used.
- star-operation improved significantly, and it also improves the variable operation.