### PR TITLE
fixes for CSV processing 

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -1949,7 +1949,7 @@ protected:
 public:
   s3select_csv_definitions m_csv_defintion;//TODO add method for modify
 
-  explicit base_s3object(s3select* m)
+  void set_base_defintions(s3select* m)
   {	
     m_s3_select=m;
     m_sa=m_s3_select->get_scratch_area();
@@ -1968,6 +1968,16 @@ public:
     }
     m_is_to_aggregate = true;//TODO not correct. should be set upon end-of-stream
     m_aggr_flow = m_s3_select->is_aggregate_query();
+  }
+
+  base_s3object():m_sa(nullptr),m_is_to_aggregate(false),m_where_clause(nullptr),m_s3_select(nullptr),m_error_count(0){}
+
+  explicit base_s3object(s3select* m)
+  {
+    if(m)
+	{
+        set_base_defintions(m);
+	}
   }
 
   virtual bool is_end_of_stream() {return false;}
@@ -2147,9 +2157,10 @@ public:
   {
     if(m_s3_select != nullptr) 
     {
-      return;
+      //return;
     }
 
+    set_base_defintions(s3_query);
     m_csv_defintion = csv;
   }
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -419,18 +419,13 @@ struct s3select : public bsc::grammar<s3select>
 private:
 
   actionQ m_actionQ;
-
   scratch_area m_sca;
-
   s3select_functions m_s3select_functions;
-
   std::string error_description;
-
   s3select_allocator m_s3select_allocator;
-
   bool aggr_flow;
-  
   bool m_json_query;
+  std::set<base_statement*> m_ast_nodes_to_delete;
 
 #define BOOST_BIND_ACTION( push_name ) boost::bind( &push_name::operator(), g_ ## push_name, const_cast<s3select*>(&self), _1, _2)
 
@@ -462,7 +457,12 @@ public:
         error_description = "nested aggregation function is illegal i.e. sum(...sum ...)";
         throw base_s3select_exception(error_description, base_s3select_exception::s3select_exp_en_t::FATAL);
       }
+
+      e->push_for_cleanup(m_ast_nodes_to_delete);
     }
+
+    if(get_filter())
+	    get_filter()->push_for_cleanup(m_ast_nodes_to_delete);
 
     if (aggr_flow == true)
     {// atleast one projection column contain aggregation function
@@ -539,6 +539,7 @@ public:
   s3select()
   {
     m_s3select_functions.setAllocator(&m_s3select_allocator);
+    m_s3select_functions.set_AST_nodes_for_cleanup(&m_ast_nodes_to_delete);
   }
 
   bool is_semantic()//TBD traverse and validate semantics per all nodes
@@ -604,7 +605,16 @@ public:
 
   ~s3select()
   {
-    m_s3select_functions.clean();
+	for(auto it : m_ast_nodes_to_delete)
+	{
+		if (it->is_function())
+      		{//upon its a function, call to the implementation destructor
+        		if(dynamic_cast<__function*>(it)->impl())
+				dynamic_cast<__function*>(it)->impl()->dtor();
+      		}
+		//calling to destrcutor of class-function itself, or non-function destructor
+		it->dtor();
+	}
   }
 
 #define JSON_ROOT_OBJECT "s3object[*]"
@@ -1277,9 +1287,6 @@ void push_column_pos::builder(s3select* self, const char* a, const char* b) cons
   {
     v = S3SELECT_NEW(self, variable, token, variable::var_t::STAR_OPERATION);
 
-    //NOTE: variable may leak upon star-operation(multi_value object is not destruct entirly, it contain stl-vactor which is allocated on heap).
-    //TODO: find a generic way for such use-cases, one possible solution is to push all-nodes(upon AST is complete) into cleanup-container.
-    self->getS3F()->push_for_cleanup(v);
   }
   else
   {
@@ -2273,27 +2280,27 @@ public:
     }
     catch(io::error::escaped_char_missing& err)
     {
-      m_error_description = "failure while csv parsing";
+      m_error_description = "escaped_char_missing failure while csv parsing";
       return -1;
     }
 	catch(io::error::escaped_string_not_closed& err)
     {
-      m_error_description = "failure while csv parsing";
+      m_error_description = "escaped_string_not_closed failure while csv parsing";
       return -1;
     }
 	catch(io::error::line_length_limit_exceeded& err)
     {
-      m_error_description = "failure while csv parsing";
+      m_error_description = "line_length_limit_exceeded failure while csv parsing";
       return -1;
     }
 	catch(io::error::with_file_name& err)
     {
-      m_error_description = "failure while csv parsing";
+      m_error_description = "with_file_name failure while csv parsing";
       return -1;
     }
 	catch(io::error::with_file_line& err)
     {
-      m_error_description = "failure while csv parsing";
+      m_error_description = "with_file_line failure while csv parsing";
       return -1;
     }
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -2271,6 +2271,31 @@ public:
       m_error_description = "out of memory";
       return -1;
     }
+    catch(io::error::escaped_char_missing& err)
+    {
+      m_error_description = "failure while csv parsing";
+      return -1;
+    }
+	catch(io::error::escaped_string_not_closed& err)
+    {
+      m_error_description = "failure while csv parsing";
+      return -1;
+    }
+	catch(io::error::line_length_limit_exceeded& err)
+    {
+      m_error_description = "failure while csv parsing";
+      return -1;
+    }
+	catch(io::error::with_file_name& err)
+    {
+      m_error_description = "failure while csv parsing";
+      return -1;
+    }
+	catch(io::error::with_file_line& err)
+    {
+      m_error_description = "failure while csv parsing";
+      return -1;
+    }
 
     return status;
   }
@@ -2302,7 +2327,7 @@ private:
       run_s3select_on_object(result, merge_line.c_str(), merge_line.length(), false, false, false);
     }
 
-    if (csv_stream[stream_length - 1] != m_csv_defintion.row_delimiter)
+    if (stream_length && csv_stream[stream_length - 1] != m_csv_defintion.row_delimiter)
     {
       //in case of "broken" last line
       char* p_obj_chunk = (char*)&(csv_stream[stream_length - 1]);

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -568,17 +568,13 @@ public:
     m_json_key = key_path;
   }
 
-  const char* to_string()  //TODO very intensive , must improve this
+  void to_string_decimal()
   {
-
-    if (type != value_En_t::STRING)
-    {
-      if (type == value_En_t::DECIMAL)
-      {
-        m_to_string = boost::lexical_cast<std::string>(__val.num);
-      }
-      else if (type == value_En_t::BOOL)
-      {
+	m_to_string = boost::lexical_cast<std::string>(__val.num);
+  }
+  
+  void to_string_bool()
+  {
         if(__val.num == 0)
         {
           m_to_string.assign("false");
@@ -587,13 +583,15 @@ public:
         {
           m_to_string.assign("true");
         }
-      }
-      else if(type == value_En_t::FLOAT)
-      {
+  }
+
+  void to_string_float()
+  {
         m_to_string = std::to_string(__val.dbl);
-      }
-      else if (type == value_En_t::TIMESTAMP)
-      {
+  }
+
+  void to_string_timestamp()
+  {
         boost::posix_time::ptime new_ptime;
         boost::posix_time::time_duration td;
         bool flag;
@@ -618,6 +616,72 @@ public:
                         std::string(2 - tz_hour.length(), '0') +  tz_hour + ":"
                         + std::string(2 - tz_mint.length(), '0') +  tz_mint;
 	}
+   }
+  
+  void to_string_str()
+  {
+      m_to_string.assign( __val.str );
+  }
+  
+  const char* to_string()  //TODO very intensive , must improve this
+  {
+
+    if (type != value_En_t::STRING)
+    {
+      if (type == value_En_t::DECIMAL)
+      {
+        //m_to_string = boost::lexical_cast<std::string>(__val.num);
+	to_string_decimal();
+      }
+      else if (type == value_En_t::BOOL)
+      {
+	      to_string_bool();
+#if 0
+        if(__val.num == 0)
+        {
+          m_to_string.assign("false");
+        }
+        else
+        {
+          m_to_string.assign("true");
+        }
+#endif
+      }
+      else if(type == value_En_t::FLOAT)
+      {
+        //m_to_string = std::to_string(__val.dbl);
+	to_string_float();
+      }
+      else if (type == value_En_t::TIMESTAMP)
+      {
+	to_string_timestamp();
+#if 0
+        boost::posix_time::ptime new_ptime;
+        boost::posix_time::time_duration td;
+        bool flag;
+
+	std::tie(new_ptime, td, flag) = *__val.timestamp;
+
+	if (flag)
+	{
+          m_to_string =  to_iso_extended_string(new_ptime) + "Z";
+	}
+        else
+	{
+          std::string tz_hour = std::to_string(std::abs(td.hours()));
+          std::string tz_mint = std::to_string(std::abs(td.minutes()));
+	  std::string sign;
+          if (td.is_negative())
+            sign = "-";
+	  else
+            sign = "+";
+
+          m_to_string =  to_iso_extended_string(new_ptime) + sign +
+                        std::string(2 - tz_hour.length(), '0') +  tz_hour + ":"
+                        + std::string(2 - tz_mint.length(), '0') +  tz_mint;
+	}
+#endif
+
       }
       else if (type == value_En_t::S3NULL)
       {
@@ -626,7 +690,8 @@ public:
     }
     else
     {
-      m_to_string.assign( __val.str );
+      //m_to_string.assign( __val.str );
+      to_string_str();
     }
 
     if(m_json_key.size())

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -146,7 +146,7 @@ public:
     _msg = n;
   }
 
-  virtual const char* what()
+  virtual const char* what() const _GLIBCXX_NOTHROW
   {
     return _msg.c_str();
   }

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -575,9 +575,9 @@ public:
     {
       if (type == value_En_t::DECIMAL)
       {
-        m_to_string.assign( boost::lexical_cast<std::string>(__val.num) );
+        m_to_string = boost::lexical_cast<std::string>(__val.num);
       }
-      if (type == value_En_t::BOOL)
+      else if (type == value_En_t::BOOL)
       {
         if(__val.num == 0)
         {

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -590,7 +590,7 @@ public:
       }
       else if(type == value_En_t::FLOAT)
       {
-        m_to_string = boost::lexical_cast<std::string>(__val.dbl);
+        m_to_string = std::to_string(__val.dbl);
       }
       else if (type == value_En_t::TIMESTAMP)
       {

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstring>
 #include <cmath>
+#include <set>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -430,10 +431,10 @@ private:
   value_t __val;
   //JSON query has a unique structure, the variable-name reside on input. there are cases were it should be extracted.
   std::vector<std::string> m_json_key;
-  //std::string m_to_string;
-  std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_to_string;
-  //std::string m_str_value;
-  std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_str_value;
+  std::string m_to_string;
+  //std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_to_string;
+  std::string m_str_value;
+  //std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_str_value;
 
 public:
   enum class value_En_t
@@ -1389,6 +1390,7 @@ public:
   bool is_column_reference() const;
   bool mark_aggreagtion_subtree_to_execute();
   bool is_statement_contain_star_operation() const;
+  void push_for_cleanup(std::set<base_statement*>&);
 
 #ifdef _ARROW_EXIST
   void extract_columns(parquet_file_parser::column_pos_t &cols,const uint16_t max_columns);

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -430,10 +430,10 @@ private:
   value_t __val;
   //JSON query has a unique structure, the variable-name reside on input. there are cases were it should be extracted.
   std::vector<std::string> m_json_key;
-  std::string m_to_string;
-  //std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_to_string;
-  std::string m_str_value;
-  //std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_str_value;
+  //std::string m_to_string;
+  std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_to_string;
+  //std::string m_str_value;
+  std::basic_string<char,std::char_traits<char>,ChunkAllocator<char,256>> m_str_value;
 
 public:
   enum class value_En_t
@@ -568,61 +568,6 @@ public:
     m_json_key = key_path;
   }
 
-  void to_string_decimal()
-  {
-	m_to_string = boost::lexical_cast<std::string>(__val.num);
-  }
-  
-  void to_string_bool()
-  {
-        if(__val.num == 0)
-        {
-          m_to_string.assign("false");
-        }
-        else
-        {
-          m_to_string.assign("true");
-        }
-  }
-
-  void to_string_float()
-  {
-        m_to_string = std::to_string(__val.dbl);
-  }
-
-  void to_string_timestamp()
-  {
-        boost::posix_time::ptime new_ptime;
-        boost::posix_time::time_duration td;
-        bool flag;
-
-	std::tie(new_ptime, td, flag) = *__val.timestamp;
-
-	if (flag)
-	{
-          m_to_string =  to_iso_extended_string(new_ptime) + "Z";
-	}
-        else
-	{
-          std::string tz_hour = std::to_string(std::abs(td.hours()));
-          std::string tz_mint = std::to_string(std::abs(td.minutes()));
-	  std::string sign;
-          if (td.is_negative())
-            sign = "-";
-	  else
-            sign = "+";
-
-          m_to_string =  to_iso_extended_string(new_ptime) + sign +
-                        std::string(2 - tz_hour.length(), '0') +  tz_hour + ":"
-                        + std::string(2 - tz_mint.length(), '0') +  tz_mint;
-	}
-   }
-  
-  void to_string_str()
-  {
-      m_to_string.assign( __val.str );
-  }
-  
   const char* to_string()  //TODO very intensive , must improve this
   {
 
@@ -630,13 +575,10 @@ public:
     {
       if (type == value_En_t::DECIMAL)
       {
-        //m_to_string = boost::lexical_cast<std::string>(__val.num);
-	to_string_decimal();
+        m_to_string.assign( boost::lexical_cast<std::string>(__val.num) );
       }
-      else if (type == value_En_t::BOOL)
+      if (type == value_En_t::BOOL)
       {
-	      to_string_bool();
-#if 0
         if(__val.num == 0)
         {
           m_to_string.assign("false");
@@ -645,17 +587,13 @@ public:
         {
           m_to_string.assign("true");
         }
-#endif
       }
       else if(type == value_En_t::FLOAT)
       {
-        //m_to_string = std::to_string(__val.dbl);
-	to_string_float();
+        m_to_string = boost::lexical_cast<std::string>(__val.dbl);
       }
       else if (type == value_En_t::TIMESTAMP)
       {
-	to_string_timestamp();
-#if 0
         boost::posix_time::ptime new_ptime;
         boost::posix_time::time_duration td;
         bool flag;
@@ -680,8 +618,6 @@ public:
                         std::string(2 - tz_hour.length(), '0') +  tz_hour + ":"
                         + std::string(2 - tz_mint.length(), '0') +  tz_mint;
 	}
-#endif
-
       }
       else if (type == value_En_t::S3NULL)
       {
@@ -690,8 +626,7 @@ public:
     }
     else
     {
-      //m_to_string.assign( __val.str );
-      to_string_str();
+      m_to_string.assign( __val.str );
     }
 
     if(m_json_key.size())

--- a/test/s3select_test.h
+++ b/test/s3select_test.h
@@ -415,7 +415,11 @@ std::string run_expression_in_C_prog(const char* expression)
 
   if(!res)
   {
-    return std::string("#ERROR#");
+  if(prog_c)
+    free(prog_c);
+
+  fclose(fp_build);
+  return std::string("#ERROR#");
   }
 
   unlink(c_run_file.c_str());


### PR DESCRIPTION
- using the new CSV parser requires changes related to the RGW flows 
- a fix for CSV processing object construction 
- refactor to AST nodes cleanup
AST nodes allocated by placement-new on top of continues-memory-block. upon releasing that block, it also requires removing heap objects that do not use the same block such as std::string.
the refactored method traverses the AST and pushes nodes into SET for cleanup later.


Signed-off-by: galsalomon66 <gal.salomon@gmail.com>