### PR TITLE
s3select -limit operator implementation

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -2314,7 +2314,6 @@ private:
     //purpose: the cv data is "streaming", it may "cut" rows in the middle, in that case the "broken-line" is stores
     //for later, upon next chunk of data is streaming, the stored-line is merge with current broken-line, and processed.
     std::string tmp_buff;
-    m_processed_bytes += stream_length;
 
     m_skip_first_line = false;
 
@@ -2352,6 +2351,7 @@ private:
       stream_length -= m_last_line.length();
     }
 
+    m_processed_bytes += stream_length;
     return run_s3select_on_object(result, csv_stream, stream_length, m_skip_first_line, m_previous_line, (m_processed_bytes >= obj_size));
   }
 
@@ -2360,8 +2360,8 @@ public:
   {
     if (do_aggregate && m_previous_line)
     {
-        stream_length += m_last_line.length();
-        m_last_line += csv_stream;
+	m_last_line.append(csv_stream,stream_length);
+        stream_length = m_last_line.length();
         m_stream = &m_last_line[0];
 	m_previous_line = false;
     }

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cstring>
 #include <cmath>
+#include <set>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
@@ -146,7 +147,7 @@ public:
     _msg = n;
   }
 
-  virtual const char* what()
+  virtual const char* what() const _GLIBCXX_NOTHROW
   {
     return _msg.c_str();
   }
@@ -1389,6 +1390,7 @@ public:
   bool is_column_reference() const;
   bool mark_aggreagtion_subtree_to_execute();
   bool is_statement_contain_star_operation() const;
+  void push_for_cleanup(std::set<base_statement*>&);
 
 #ifdef _ARROW_EXIST
   void extract_columns(parquet_file_parser::column_pos_t &cols,const uint16_t max_columns);

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -459,7 +459,7 @@ public:
   {
     __val.num = n;
   }
-  explicit value(bool b) : type(value_En_t::DECIMAL)
+  explicit value(bool b) : type(value_En_t::BOOL)
   {
     __val.num = (int64_t)b;
   }

--- a/test/s3select_perf_test.cpp
+++ b/test/s3select_perf_test.cpp
@@ -13,7 +13,7 @@ void run_query(std::string& query, std::string& csv, std::string profiler_file, 
 
   ProfilerStart(profiler_file.c_str());
 
-  result = run_s3select(query, csv);
+  result = run_s3select(query, csv,JSON_NO_RUN);
 
   ProfilerFlush();
   ProfilerStop();
@@ -460,7 +460,7 @@ TEST(TestS3SelectPerformance, LIKE_CONSTANT_SMALL)
 
   run_query(input_query, input_csv, "./perf_.txt", s3select_res);
 
-  EXPECT_EQ(s3select_res, "100000");
+  EXPECT_EQ(s3select_res,std::to_string(COUNT).c_str());
 }
 
 TEST(TestS3SelectPerformance, LIKE_CONSTANT_LARGE)
@@ -472,7 +472,7 @@ TEST(TestS3SelectPerformance, LIKE_CONSTANT_LARGE)
 
   run_query(input_query, input_csv, "./perf_.txt", s3select_res);
 
-  EXPECT_EQ(s3select_res, "100000");
+  EXPECT_EQ(s3select_res, std::to_string(COUNT).c_str());
 }
 
 TEST(TestS3SelectPerformance, LIKE_DYNAMIC)
@@ -484,5 +484,5 @@ TEST(TestS3SelectPerformance, LIKE_DYNAMIC)
 
   run_query(input_query, input_csv, "./perf_.txt", s3select_res);
 
-  EXPECT_EQ(s3select_res, "100000");
+  EXPECT_EQ(s3select_res, std::to_string(COUNT).c_str());
 }

--- a/test/s3select_test.h
+++ b/test/s3select_test.h
@@ -40,6 +40,7 @@ using parquet::schema::PrimitiveNode;
 constexpr int NUM_ROWS = 100000;
 constexpr int64_t ROW_GROUP_SIZE = 1024 * 1024;
 const char PARQUET_FILENAME[] = "/tmp/csv_converted.parquet";
+#define JSON_NO_RUN "no_run"
 
 class tokenize {
 
@@ -694,8 +695,10 @@ std::string run_s3select(std::string expression,std::string input, const char* j
     json_query = convert_query(expression);
   }
 
-  run_json_query(json_query, js, json_result);
-  json_csv_report_error(json_result, s3select_result);
+  if(strcmp(json_query,JSON_NO_RUN)) {
+	run_json_query(json_query, js, json_result);
+	json_csv_report_error(json_result, s3select_result);
+  }
 
   return s3select_result;
 }

--- a/test/s3select_test.h
+++ b/test/s3select_test.h
@@ -415,7 +415,11 @@ std::string run_expression_in_C_prog(const char* expression)
 
   if(!res)
   {
-    return std::string("#ERROR#");
+  if(prog_c)
+    free(prog_c);
+
+  fclose(fp_build);
+  return std::string("#ERROR#");
   }
 
   unlink(c_run_file.c_str());


### PR DESCRIPTION
The LIMIT SQL command enables to limit the amount of scanned data

Signed-off-by: Girjesh Rajoria <girjesh.rajoria@gmail.com>