### PR TITLE
syntax rule fix

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -641,7 +641,7 @@ public:
 
       when_value_then = (S3SELECT_KW("when") >> arithmetic_expression >> S3SELECT_KW("then") >> arithmetic_expression)[BOOST_BIND_ACTION(push_when_value_then)];
 
-      from_expression = (s3_object >> (variable - S3SELECT_KW("where"))) | s3_object;
+      from_expression = (s3_object >> variable_name ) | s3_object;
 
       //the stdin and object_path are for debug purposes(not part of the specs)
       s3_object = json_s3_object | S3SELECT_KW("stdin") | S3SELECT_KW("s3object") | object_path;
@@ -694,9 +694,10 @@ public:
 
       list_of_function_arguments = (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)] >> *(',' >> (arithmetic_expression)[BOOST_BIND_ACTION(push_function_arg)]);
 
-      reserved_function_names = (S3SELECT_KW("when")|S3SELECT_KW("case")|S3SELECT_KW("then")|S3SELECT_KW("not"));
+      reserved_function_names = (S3SELECT_KW("when")|S3SELECT_KW("case")|S3SELECT_KW("then")|S3SELECT_KW("not")|S3SELECT_KW("limit")|S3SELECT_KW("where")|S3SELECT_KW("in")|S3SELECT_KW("between") |
+				S3SELECT_KW("like")|S3SELECT_KW("is") );
      
-      function = ( ((variable - reserved_function_names)  >> '(' )[BOOST_BIND_ACTION(push_function_name)] >> !list_of_function_arguments >> ')')[BOOST_BIND_ACTION(push_function_expr)];
+      function = ( ((variable_name)  >> '(' )[BOOST_BIND_ACTION(push_function_name)] >> !list_of_function_arguments >> ')')[BOOST_BIND_ACTION(push_function_expr)];
 
       arithmetic_argument = (float_number)[BOOST_BIND_ACTION(push_float_number)] |  (number)[BOOST_BIND_ACTION(push_number)] | (json_variable_name)[BOOST_BIND_ACTION(push_json_variable)] |
 			    (column_pos)[BOOST_BIND_ACTION(push_column_pos)] |


### PR DESCRIPTION
upon introducing new syntax, it may fail because of other rules that do not exclude reserved words.

TODO: the list of reserved words is much longer.

Signed-off-by: gal salomon <gal.salomon@gmail.com>