### PR TITLE
value: fix the bool constructor's value type

### DIFF
--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -458,7 +458,7 @@ public:
   {
     __val.num = n;
   }
-  explicit value(bool b) : type(value_En_t::DECIMAL)
+  explicit value(bool b) : type(value_En_t::BOOL)
   {
     __val.num = (int64_t)b;
   }


### PR DESCRIPTION
change the `value(bool)` constructor to match the `BOOL` value type used by `operator=(bool)`, so that `to_string()` will render it as `false`/`true` instead of `0`/`1`