### PR TITLE
NULL handling missing for some of parquet-types

### DIFF
--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1228,18 +1228,15 @@ public:
       switch( v.type )
       {
         case  parquet_file_parser::parquet_type::INT32:
-              //TODO waste of CPU
-              (*m_schema_values)[ *column_pos_iter ] = value( v.num ).i64();
+              (*m_schema_values)[ *column_pos_iter ] = v.num;
               break;
 
         case  parquet_file_parser::parquet_type::INT64:
-              //TODO waste of CPU
-              (*m_schema_values)[ *column_pos_iter ] = value( v.num ).i64();
+              (*m_schema_values)[ *column_pos_iter ] = v.num;
               break;
 
         case  parquet_file_parser::parquet_type::DOUBLE:
-              //TODO waste of CPU
-              (*m_schema_values)[ *column_pos_iter ] = value( v.dbl ).dbl();
+              (*m_schema_values)[ *column_pos_iter ] =  v.dbl;
               break;
 
         case  parquet_file_parser::parquet_type::STRING:
@@ -1257,11 +1254,9 @@ public:
               (*m_schema_values)[ *column_pos_iter ].setnull();
 	      break;
 
-        case  parquet_file_parser::parquet_type::TIMESTAMP: //TODO mili-sec, micro-sec, nano-sec
-              //TODO waste of CPU
+        case  parquet_file_parser::parquet_type::TIMESTAMP: //TODO milli-sec, micro-sec, nano-sec
 	      {
-		//int64_t tm = value( v.num ).i64();
-		auto tm_sec = v.num/S3SELECT_MICROSEC; //TODO what is the unit?
+		auto tm_sec = v.num/S3SELECT_MICROSEC; //TODO should use the correct unit 
 		boost::posix_time::ptime new_ptime = boost::posix_time::from_time_t( tm_sec ); 
 		boost::posix_time::time_duration td_zero((tm_sec/3600)%24,(tm_sec/60)%24,tm_sec%60);
 		tmstmp = std::make_tuple(new_ptime, td_zero, (char)'Z');

--- a/include/s3select_parquet_intrf.h
+++ b/include/s3select_parquet_intrf.h
@@ -1245,7 +1245,7 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
   }
 
   file_metadata_ =
-      FileMetaData::Make(metadata_buffer->data(), &metadata_len, file_decryptor_);
+      FileMetaData::Make(metadata_buffer->data(), &metadata_len, default_reader_properties(), file_decryptor_);
 }
 
 void SerializedFile::ParseMetaDataOfEncryptedFileWithPlaintextFooter(

--- a/include/s3select_parquet_intrf.h
+++ b/include/s3select_parquet_intrf.h
@@ -1521,6 +1521,7 @@ public:
     STRING,
     INT32,
     INT64,
+    FLOAT,
     DOUBLE,
     TIMESTAMP,
     PARQUET_NULL
@@ -1630,6 +1631,11 @@ private:
 
       case parquet::Type::type::INT64:
         elm = std::pair<std::string, column_reader_wrap::parquet_type>(m_file_metadata->schema()->Column(i)->name(), column_reader_wrap::parquet_type::INT64);
+        m_schm.push_back(elm);
+        break;
+
+      case parquet::Type::type::FLOAT:
+        elm = std::pair<std::string, column_reader_wrap::parquet_type>(m_file_metadata->schema()->Column(i)->name(), column_reader_wrap::parquet_type::FLOAT);
         m_schm.push_back(elm);
         break;
 
@@ -1744,6 +1750,7 @@ private:
   {
     parquet::Int32Reader* int32_reader;
     parquet::Int64Reader* int64_reader;
+    parquet::FloatReader* float_reader;
     parquet::DoubleReader* double_reader;
     parquet::ByteArrayReader* byte_array_reader;
 
@@ -1759,6 +1766,11 @@ private:
       return int64_reader->HasNext();
       break;
 
+    case parquet::Type::type::FLOAT:
+      float_reader = static_cast<parquet::FloatReader *>(m_ColumnReader.get());
+      return float_reader->HasNext();
+      break;
+
     case parquet::Type::type::DOUBLE:
       double_reader = static_cast<parquet::DoubleReader *>(m_ColumnReader.get());
       return double_reader->HasNext();
@@ -1770,6 +1782,11 @@ private:
       break;
 
     default:
+
+        std::stringstream err;
+        err << "HasNext():" << "wrong type or type not exist" << std::endl;
+        throw std::runtime_error(err.str());
+
       return false;
       //TODO throw exception
     }
@@ -1782,6 +1799,7 @@ private:
   {
     parquet::Int32Reader* int32_reader;
     parquet::Int64Reader* int64_reader;
+    parquet::FloatReader* float_reader;
     parquet::DoubleReader* double_reader;
     parquet::ByteArrayReader* byte_array_reader;
 
@@ -1830,7 +1848,33 @@ private:
 		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
       	} else
       	{
-      		values->type = column_reader_wrap::parquet_type::INT64;
+		auto logical_type = m_parquet_reader->metadata()->schema()->Column(m_col_id)->logical_type();
+
+                if (logical_type.get()->type() == parquet::LogicalType::Type::type::TIMESTAMP) //TODO missing sub-type (milli,micro)
+                        values->type = column_reader_wrap::parquet_type::TIMESTAMP;
+                else
+                        values->type = column_reader_wrap::parquet_type::INT64;
+      	}
+      }
+      catch(std::exception &e)
+      {
+         throw std::runtime_error(error_msg(e).str());
+      }
+      break;
+
+    case parquet::Type::type::FLOAT:
+        float_reader = static_cast<parquet::FloatReader *>(m_ColumnReader.get());
+      try{
+	float data_source_float = 0;
+      	rows_read = float_reader->ReadBatch(1, &defintion_level, &repeat_level, &data_source_float , values_read);//TODO proper cast
+      	if(defintion_level == 0)
+      	{
+		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
+      	} else
+      	{
+      		values->type = column_reader_wrap::parquet_type::DOUBLE;
+		values->dbl = data_source_float;
+
       	}
       }
       catch(std::exception &e)
@@ -1894,6 +1938,7 @@ private:
     parquet::Int32Reader* int32_reader;
     parquet::Int64Reader* int64_reader;
     parquet::DoubleReader* double_reader;
+    parquet::FloatReader* float_reader;
     parquet::ByteArrayReader* byte_array_reader;
 
     parquet::ByteArray str_value;
@@ -1924,6 +1969,17 @@ private:
       int64_reader = static_cast<parquet::Int64Reader *>(m_ColumnReader.get());
       try{
         rows_read = int64_reader->Skip(rows_to_skip);
+      }
+      catch(std::exception &e)
+      {
+        throw std::runtime_error(error_msg(e).str());
+      }
+      break;
+
+    case parquet::Type::type::FLOAT:
+      float_reader = static_cast<parquet::FloatReader *>(m_ColumnReader.get());
+      try {
+        rows_read = float_reader->Skip(rows_to_skip);
       }
       catch(std::exception &e)
       {
@@ -1973,6 +2029,7 @@ private:
     { //should skip
       m_read_last_value = false;
 
+      //TODO what about Skip(0)
       uint64_t skipped_rows = Skip(rownum - m_rownum -1);
       m_rownum += skipped_rows;
 

--- a/include/s3select_parquet_intrf.h
+++ b/include/s3select_parquet_intrf.h
@@ -1804,58 +1804,76 @@ private:
     case parquet::Type::type::INT32:
       int32_reader = static_cast<parquet::Int32Reader *>(m_ColumnReader.get());
       try {
-        rows_read = int32_reader->ReadBatch(1, nullptr, nullptr,&i32_val, values_read);
+	rows_read = int32_reader->ReadBatch(1, &defintion_level, &repeat_level, &i32_val , values_read);
+      	if(defintion_level == 0)
+      	{
+		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
+      	} else
+      	{
+      		values->num = i32_val;
+      		values->type = column_reader_wrap::parquet_type::INT32;
+      	}
       }
       catch(std::exception &e)
       {
          throw std::runtime_error(error_msg(e).str());
       }
 
-      values->num = i32_val;
-      values->type = column_reader_wrap::parquet_type::INT32;
       break;
 
     case parquet::Type::type::INT64:
       int64_reader = static_cast<parquet::Int64Reader *>(m_ColumnReader.get());
       try{
-        rows_read = int64_reader->ReadBatch(1, nullptr, nullptr, (int64_t *)&(values->num), values_read);
+        rows_read = int64_reader->ReadBatch(1, &defintion_level, &repeat_level, (int64_t *)&(values->num), values_read);
+      	if(defintion_level == 0)
+      	{
+		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
+      	} else
+      	{
+      		values->type = column_reader_wrap::parquet_type::INT64;
+      	}
       }
       catch(std::exception &e)
       {
          throw std::runtime_error(error_msg(e).str());
       }
-      values->type = column_reader_wrap::parquet_type::INT64;
       break;
 
     case parquet::Type::type::DOUBLE:
-      try{
         double_reader = static_cast<parquet::DoubleReader *>(m_ColumnReader.get());
+      try{
+      	rows_read = double_reader->ReadBatch(1, &defintion_level, &repeat_level, (double *)&(values->dbl), values_read);
+      	if(defintion_level == 0)
+      	{
+		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
+      	} else
+      	{
+      		values->type = column_reader_wrap::parquet_type::DOUBLE;
+      	}
       }
       catch(std::exception &e)
       {
          throw std::runtime_error(error_msg(e).str());
       }
-      rows_read = double_reader->ReadBatch(1, nullptr, nullptr, (double *)&(values->dbl), values_read);
-      values->type = column_reader_wrap::parquet_type::DOUBLE;
       break;
 
     case parquet::Type::type::BYTE_ARRAY:
       byte_array_reader = static_cast<parquet::ByteArrayReader *>(m_ColumnReader.get());
       try{
         rows_read = byte_array_reader->ReadBatch(1, &defintion_level, &repeat_level, &str_value , values_read);
+      	if(defintion_level == 0)
+      	{	
+		values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
+      	} else
+      	{
+		values->type = column_reader_wrap::parquet_type::STRING;
+      		values->str = (char*)str_value.ptr;
+      		values->str_len = str_value.len;
+      	}
       }
       catch(std::exception &e)
       {
          throw std::runtime_error(error_msg(e).str());
-      }
-      values->str = (char*)str_value.ptr;
-      values->str_len = str_value.len;
-      if(defintion_level == 0)
-      {
-	values->type = column_reader_wrap::parquet_type::PARQUET_NULL;
-      } else
-      {
-	values->type = column_reader_wrap::parquet_type::STRING;
       }
       break;
 


### PR DESCRIPTION
the following to be fixed
- for some of the types the null handling is missing
- the TIMESTAMP(INT64) type is not handled, what about int96?
- FLOAT type is missing (we have DOUBLE) 
- test use case https://ursa-labs-taxi-data.s3.us-east-2.amazonaws.com/ (it contain many parquet objects)

Signed-off-by: galsalomon66 <gal.salomon@gmail.com>