### PR TITLE
issues related to TPCDS benchmark 

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -2435,7 +2435,7 @@ public:
 }; //base_s3object
 
 //TODO config / default-value
-#define CSV_INPUT_TYPE_RESPONSE_SIZE_LIMIT (4 * 1024)
+#define CSV_INPUT_TYPE_RESPONSE_SIZE_LIMIT (64 * 1024)
 class csv_object : public base_s3object
 {
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -542,11 +542,7 @@ public:
 
     try
     {
-//NOTE: bellow is a temoprary fix(workaround) for a failed syntax parsing(cause a crash)
-// the crash happens in boost-spirit. the reason for thar is not clear, yet.
-      std::string replaced_query = std::regex_replace(input_query, std::regex(" INT"), " int");
-
-      bsc::parse_info<> info = bsc::parse(replaced_query.c_str(), *this, bsc::space_p);
+      bsc::parse_info<> info = bsc::parse(input_query, *this, bsc::space_p);
       auto query_parse_position = info.stop;
 
       if (!info.full)
@@ -772,9 +768,9 @@ public:
                             (cast) | (substr) | (trim) | (when_case_value_when) | (when_case_else_projection) |
                             (function) | (variable)[BOOST_BIND_ACTION(push_variable)]; //function is pushed by right-term
 
-      cast = (S3SELECT_KW("cast") >> '(' >> factor >> S3SELECT_KW("as") >> (data_type)[BOOST_BIND_ACTION(push_data_type)] >> ')') [BOOST_BIND_ACTION(push_cast_expr)];
+      cast = (S3SELECT_KW("cast") >> '(' >> factor >> S3SELECT_KW("as") >> (data_type) >> ')') [BOOST_BIND_ACTION(push_cast_expr)];
 
-      data_type = (S3SELECT_KW("int") | S3SELECT_KW("float") | S3SELECT_KW("string") |  S3SELECT_KW("timestamp") | S3SELECT_KW("bool") );
+      data_type = (S3SELECT_KW("int") | S3SELECT_KW("float") | S3SELECT_KW("string") |  S3SELECT_KW("timestamp") | S3SELECT_KW("bool") )[BOOST_BIND_ACTION(push_data_type)];
      
       substr = (substr_from) | (substr_from_for);
       
@@ -1761,7 +1757,7 @@ void push_data_type::builder(s3select* self, const char* a, const char* b) const
 {
   std::string token(a, b);
 
-  auto cast_operator = [&](const char *s){return strncmp(a,s,strlen(s))==0;};
+  auto cast_operator = [&](const char *s){return strncasecmp(a,s,strlen(s))==0;};
 
   if(cast_operator("int"))
   {

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -695,7 +695,7 @@ public:
 	}
   if(m_to_timestamp_for_clean)
   { 
-    m_to_timestamp_for_clean->dtor(); //TODO : to use the m_ast_nodes_to_delete vector
+    m_to_timestamp_for_clean->dtor();
   }
   }
 

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -419,8 +419,7 @@ public:
     return true;
   }
 
-  __function(const char* fname, s3select_functions* s3f) : name(fname), m_func_impl(nullptr), m_s3select_functions(s3f),m_is_aggregate_function(false) 
-  {}
+  __function(const char* fname, s3select_functions* s3f) : name(fname), m_func_impl(nullptr), m_s3select_functions(s3f),m_is_aggregate_function(false){set_operator_name(fname);}
 
   value& eval() override
   {

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -787,7 +787,7 @@ struct _fn_to_timestamp : public base_function
                                 >> (dig2[BOOST_BIND_ACTION_PARAM(push_2dig, &mo)]) >> *(date_separator)
                                 >> (dig2[BOOST_BIND_ACTION_PARAM(push_2dig, &dy)]) >> *(delimiter));
 
-  uint32_t hr = 0, mn = 0, sc = 0,  frac_sec = 0, tz_hr = 0, tz_mn = 0, sign, tm_zone = '0';
+  uint32_t hr = 0, mn = 0, sc = 0,  frac_sec = 0, tz_hr = 0, tz_mn = 0, sign = 0, tm_zone = '0';
 
   #if BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
     bsc::rule<> fdig9 = bsc::lexeme_d[bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p >> bsc::digit_p];

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -1866,7 +1866,7 @@ struct _fn_when_value_then : public base_function {
     when_value = when_expr->eval();
     case_value = case_expr->eval();
     then_value = then_expr->eval();
-    
+
     if (case_value == when_value)
     {
         *result = then_value;

--- a/include/s3select_json_parser.h
+++ b/include/s3select_json_parser.h
@@ -515,6 +515,8 @@ class JsonParserHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     int m_current_depth;
     bool m_star_operation;
     int m_sql_processing_status;
+    bool m_fatal_initialization_ind = false;
+    std::string m_fatal_initialization_description;
 
     JsonParserHandler() : prefix_match(false),init_buffer_stream(false),m_start_row_depth(-1),m_current_depth(0),m_star_operation(false),m_sql_processing_status(0)
     {
@@ -722,6 +724,11 @@ class JsonParserHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
     void set_star_operation()
     {
       m_star_operation = true;
+    }
+
+    bool is_fatal_initialization()
+    {
+      return m_fatal_initialization_ind;
     }
 
     int process_json_buffer(char* json_buffer,size_t json_buffer_sz, bool end_of_stream=false)

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1546,14 +1546,7 @@ public:
       _name = "#";
       m_var_type = tp;
       column_pos = -1;
-	// upon expression contains an empty string (TODO: tests for empty string)
-      if (n.size() == 0){
-	var_value.setnull(); 
-      }
-      else {
-	var_value = n.c_str();
-      }
-      
+      var_value = n.c_str();
     }
     else if (tp ==variable::var_t::STAR_OPERATION)
     {

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1175,6 +1175,12 @@ public:
   void update(std::vector<char*>& tokens, size_t num_of_tokens)
   {
     size_t i=0;
+    //increase the Vector::m_schema_values capacity(it should happen few times)
+    if ((*m_schema_values).capacity() < tokens.size())
+    {
+	  (*m_schema_values).resize( tokens.size() * 2 );
+    }
+
     for(auto s : tokens)
     {
       if (i>=num_of_tokens)
@@ -1229,6 +1235,13 @@ public:
     {
       max_json_idx = json_idx;
     }
+
+    //increase the Vector::m_schema_values capacity(it should happen few times)
+    if ((*m_schema_values).capacity() < static_cast<unsigned long long>(max_json_idx))
+    {
+	  (*m_schema_values).resize(max_json_idx * 2);
+    }
+
     (*m_schema_values)[ json_idx ] = v;
 
     if(json_idx>m_upper_bound)
@@ -1250,6 +1263,12 @@ public:
     parquet_file_parser::column_pos_t::iterator column_pos_iter = column_positions.begin();
     m_upper_bound =0;
     buff_loc=0;
+
+    //increase the Vector::m_schema_values capacity(it should happen few times)
+    if ((*m_schema_values).capacity() < parquet_row_value.size())
+    {
+	  (*m_schema_values).resize(parquet_row_value.size() * 2);
+    }
 
     for(auto v : parquet_row_value)
     {

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1333,7 +1333,9 @@ public:
 
   void set_operator_name(const char* op)
   {
+#ifdef S3SELECT_PROF
     operator_name = op;
+#endif
   }
 
   virtual value& eval()

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -941,8 +941,14 @@ public:
     if (lhs.is_nan() || rhs.is_nan())
     {
       return false;
-    }  
+    }
 
+//  in the case of NULL on right-side or NULL on left-side, the result is false.
+    if(lhs.is_null() || rhs.is_null())
+    {
+      return false;
+    }
+    
     throw base_s3select_exception("operands not of the same type(numeric , string), while comparision");
   }
   bool operator<=(const value& v)
@@ -1540,7 +1546,14 @@ public:
       _name = "#";
       m_var_type = tp;
       column_pos = -1;
-      var_value = n.c_str();
+	// upon expression contains an empty string (TODO: tests for empty string)
+      if (n.size() == 0){
+	var_value.setnull(); 
+      }
+      else {
+	var_value = n.c_str();
+      }
+      
     }
     else if (tp ==variable::var_t::STAR_OPERATION)
     {
@@ -1752,8 +1765,9 @@ public:
     {
       m_scratch->get_column_value(column_pos,var_value);
       //in the case of successive column-delimiter {1,some_data,,3}=> third column is NULL 
-      if (var_value.is_string() && (var_value.str()== 0 || (var_value.str() && *var_value.str()==0)))
+      if (var_value.is_string() && (var_value.str()== 0 || (var_value.str() && *var_value.str()==0))){
           var_value.setnull();//TODO is it correct for Parquet
+      }
     }
 
     return var_value;

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -1368,7 +1368,7 @@ TEST(TestS3selectFunctions, multirow_datetime_to_string_dynamic)
 
 TEST(TestS3selectFunctions, backtick_on_timestamp)
 {
-  const std::string input = "1994-11-21T11:49:23Z";
+  const std::string input = "1994-11-21T11:49:23Z\n";
   const std::string input_query = "select count(0) from s3object where cast(_1 as timestamp) = `1994-11-21T11:49:23Z`;";
   std::string s3select_result = run_s3select(input_query, input);
   EXPECT_EQ(s3select_result, "1");

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -1318,6 +1318,13 @@ TEST(TestS3selectFunctions, test_cast_expressions)
   std::string s3select_result_4 = run_s3select(input_query_4,input);
 
   ASSERT_EQ(s3select_result_3, s3select_result_4);
+
+  //testing the decimal operator for precision setting
+  const std::string input_query_5 = "select cast(1.123456789 as decimal(9,1)) from s3object limit 1;";
+
+  std::string s3select_result_5 = run_s3select(input_query_5,input);
+
+  ASSERT_EQ(s3select_result_5, "1.123456789\n");
 }
 
 TEST(TestS3selectFunctions, test_version)
@@ -1357,6 +1364,14 @@ TEST(TestS3selectFunctions, multirow_datetime_to_string_dynamic)
   const std::string input_query = "select to_string(to_timestamp(_1), _2) from s3object;";
   std::string s3select_result = run_s3select(input_query, input);
   EXPECT_EQ(s3select_result, expected_res);
+}
+
+TEST(TestS3selectFunctions, backtick_on_timestamp)
+{
+  const std::string input = "1994-11-21T11:49:23Z";
+  const std::string input_query = "select count(0) from s3object where cast(_1 as timestamp) = `1994-11-21T11:49:23Z`;";
+  std::string s3select_result = run_s3select(input_query, input);
+  EXPECT_EQ(s3select_result, "1");
 }
 
 TEST(TestS3selectFunctions, test_date_time_expressions)
@@ -2343,7 +2358,7 @@ test_single_column_single_row( "select cast(5.123 as int) from stdin ;" ,"5\n");
 
 TEST(TestS3selectFunctions, castfloat)
 {
-test_single_column_single_row( "select cast(1.234 as float) from stdin ;" ,"1.234\n");
+test_single_column_single_row( "select cast(1.234 as FLOAT) from stdin ;" ,"1.234\n");
 }
 
 TEST(TestS3selectFunctions, castfloatoperation)


### PR DESCRIPTION
1. upon comparison of values, the NULL use-case was missing.
2. missing decimal type operator.
3. upon CAST(X AS INT) construct(capital INT), it causes segfault.
4. where clause evaluation is called more than once(twice) for the same predicate, it causes performance degradation. 
5. add backtick(`) operator, upon backtick on timestamp string(constant), it is converted to timestamp, in parsing time. 
6. code profiling: upon compile definition, the engine provides the number of calls per operator node.
7. remove redundant statement evaluation in the compare operator. 