### PR TITLE
hive.s3.endpoint should be a URL format

### DIFF
--- a/container/trino/trino/catalog/hive.properties
+++ b/container/trino/trino/catalog/hive.properties
@@ -16,6 +16,9 @@ hive.s3.aws-secret-key=b234567890123456789012345678901234567890
 
 # should modify per s3-endpoint-url
 hive.s3.endpoint=http://172.17.0.1:8000
+#hive.s3.endpoint=10.35.206.20
+#hive.s3.endpoint=172.21.48.86
+
 
 
 #hive.s3.max-connections=1


### PR DESCRIPTION
this parameter must be in a URL format 
otherwise, it cause a failure (not connecting to RGW).