### PR TITLE
fixes for QE runs

### DIFF
--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -370,7 +370,7 @@ private:
     }
     m_func_impl = f;
     m_is_aggregate_function= m_func_impl->is_aggregate();
-
+    f->set_function_name(name.c_str());
   }
 
 public:
@@ -497,6 +497,8 @@ struct _fn_add : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,2);
+
     auto iter = args->begin();
     base_statement* x =  *iter;
     iter++;
@@ -522,6 +524,8 @@ struct _fn_sum : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter = args->begin();
     base_statement* x = *iter;
 
@@ -593,6 +597,8 @@ struct _fn_avg : public base_function
 
     bool operator()(bs_stmt_vec_t* args, variable *result) override
     {
+	check_args_size(args,1);
+
         auto iter = args->begin();
         base_statement *x = *iter;
 
@@ -631,6 +637,8 @@ struct _fn_min : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter = args->begin();
     base_statement* x =  *iter;
 
@@ -661,6 +669,8 @@ struct _fn_max : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter = args->begin();
     base_statement* x =  *iter;
 
@@ -685,6 +695,8 @@ struct _fn_to_int : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     value v = (*args->begin())->eval();
 
     switch (v.type) {
@@ -730,6 +742,8 @@ struct _fn_to_float : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     value v = (*args->begin())->eval();
 
     switch (v.type) {
@@ -1478,6 +1492,8 @@ struct _fn_isnull : public base_function
   
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter = args->begin();
     base_statement* expr = *iter;
     value expr_val = expr->eval();
@@ -1516,6 +1532,8 @@ struct _fn_in : public base_function
 
   bool operator()(bs_stmt_vec_t *args, variable *result) override
   {
+    check_args_size(args,1);
+
     int args_size = static_cast<int>(args->size()-1);
     base_statement *main_expr = (*args)[args_size];
     value main_expr_val = main_expr->eval();
@@ -1565,6 +1583,8 @@ struct _fn_like : public base_like
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,3);
+
     auto iter = args->begin();
 
     base_statement* escape_expr = *iter;
@@ -1723,6 +1743,8 @@ struct _fn_charlength : public base_function {
  
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
         auto iter = args->begin();
         base_statement* str =  *iter;
         v_str = str->eval();
@@ -1734,7 +1756,7 @@ struct _fn_charlength : public base_function {
             return true; 
             }
         }
-    };
+};
 
 struct _fn_lower : public base_function {
 
@@ -1743,6 +1765,8 @@ struct _fn_lower : public base_function {
 
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
         auto iter = args->begin();
         base_statement* str = *iter;
         v_str = str->eval();
@@ -1764,6 +1788,8 @@ struct _fn_upper : public base_function {
 
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
         auto iter = args->begin();
         base_statement* str = *iter;
         v_str = str->eval();
@@ -1828,6 +1854,8 @@ struct _fn_when_then : public base_function {
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,2);
+
     auto iter = args->begin();
 
     base_statement* then_expr = *iter;
@@ -1857,6 +1885,8 @@ struct _fn_when_value_then : public base_function {
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,3);
+
     auto iter = args->begin();
 
     base_statement* then_expr = *iter;
@@ -1888,6 +1918,8 @@ struct _fn_case_when_else : public base_function {
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     base_statement* else_expr = *(args->begin());
 
     size_t args_size = args->size() -1;
@@ -1916,6 +1948,8 @@ struct _fn_coalesce : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter_begin = args->begin();
     int args_size = args->size();
     while (args_size >= 1)
@@ -1941,6 +1975,8 @@ struct _fn_string : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     auto iter = args->begin();
 
     base_statement* expr = *iter;
@@ -1957,6 +1993,8 @@ struct _fn_to_bool : public base_function
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
+    check_args_size(args,1);
+
     int64_t i=0;
     func_arg = (*args->begin())->eval();
 
@@ -1997,6 +2035,8 @@ struct _fn_trim : public base_function {
 
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
     	auto iter = args->begin();
     	int args_size = args->size();
     	base_statement* str = *iter;
@@ -2030,6 +2070,8 @@ struct _fn_leading : public base_function {
 
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
     	auto iter = args->begin();
     	int args_size = args->size();
     	base_statement* str = *iter;
@@ -2062,6 +2104,8 @@ struct _fn_trailing : public base_function {
 
     bool operator()(bs_stmt_vec_t* args, variable* result) override
     {
+	check_args_size(args,1);
+
     	auto iter = args->begin();
     	int args_size = args->size();
     	base_statement* str = *iter;
@@ -2089,6 +2133,7 @@ struct _fn_cast_to_decimal : public base_function {
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
     //cast(expr as decimal(x,y))
+    check_args_size(args,2);
 
     base_statement* expr = (*args)[1];
     //expr_val should be float or integer
@@ -2118,6 +2163,8 @@ struct _fn_decimal_operator : public base_function {
   bool operator()(bs_stmt_vec_t* args, variable* result) override
   {
     //decimal(x,y) operator
+    check_args_size(args,2);
+
     auto iter = args->begin();
     base_statement* expr_precision = *iter;
     value expr_precision_val = expr_precision->eval();

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1218,7 +1218,7 @@ public:
   {
     if (column_pos > ((*m_schema_values).size()-1))
     {
-      throw base_s3select_exception("accessing scratch buffer byound its size");
+      throw base_s3select_exception("accessing scratch buffer beyond its size");
     }
 
     v = (*m_schema_values)[ column_pos ];
@@ -1228,7 +1228,7 @@ public:
   {
     if (column_pos > ((*m_schema_values).size()-1))
     {
-      throw base_s3select_exception("accessing scratch buffer byound its size");
+      throw base_s3select_exception("accessing scratch buffer beyond its size");
     }
 
     return &(*m_schema_values)[ column_pos ];
@@ -1282,7 +1282,7 @@ public:
 
     if (*column_pos_iter > ((*m_schema_values).size()-1))
     {
-      throw base_s3select_exception("accessing scratch buffer byound its size");
+      throw base_s3select_exception("accessing scratch buffer beyond its size");
     }
 
     for(auto v : parquet_row_value)

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1144,7 +1144,7 @@ public:
   json_star_op_cont_t m_json_star_operation;
 
   scratch_area():m_upper_bound(-1),parquet_type(false),buff_loc(0),max_json_idx(-1)
-  {//TODO it should resize dynamicly
+  {
     m_schema_values = new std::vector<value>(128,value(nullptr));
   }
 
@@ -1215,12 +1215,22 @@ public:
   }
 
   void get_column_value(uint16_t column_pos, value &v)
-  {// TODO handle out of boundaries
+  {
+    if (column_pos > ((*m_schema_values).size()-1))
+    {
+      throw base_s3select_exception("accessing scratch buffer byound its size");
+    }
+
     v = (*m_schema_values)[ column_pos ];
   }
 
   value* get_column_value(uint16_t column_pos)
   {
+    if (column_pos > ((*m_schema_values).size()-1))
+    {
+      throw base_s3select_exception("accessing scratch buffer byound its size");
+    }
+
     return &(*m_schema_values)[ column_pos ];
   }
   
@@ -1268,6 +1278,11 @@ public:
     if ((*m_schema_values).capacity() < parquet_row_value.size())
     {
 	  (*m_schema_values).resize(parquet_row_value.size() * 2);
+    }
+
+    if (*column_pos_iter > ((*m_schema_values).size()-1))
+    {
+      throw base_s3select_exception("accessing scratch buffer byound its size");
     }
 
     for(auto v : parquet_row_value)

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -2260,6 +2260,7 @@ public:
   //TODO add semantic to base-function , it operate once on function creation
   // validate semantic on creation instead on run-time
   virtual bool operator()(bs_stmt_vec_t* args, variable* result) = 0;
+  std::string m_function_name;
   base_function() : aggregate(false) {}
   bool is_aggregate() const
   {
@@ -2274,6 +2275,27 @@ public:
     this->~base_function();
   }
 
+  void check_args_size(bs_stmt_vec_t* args, uint16_t required, const char* error_msg)
+  {//verify for atleast required parameters
+    if(args->size() < required)
+    {
+      throw base_s3select_exception(error_msg,base_s3select_exception::s3select_exp_en_t::FATAL);
+    }
+  }
+
+  void check_args_size(bs_stmt_vec_t* args,uint16_t required)
+  {
+    if(args->size() < required)
+    {
+      std::string error_msg = m_function_name + " requires for " + std::to_string(required) + " arguments";
+      throw base_s3select_exception(error_msg,base_s3select_exception::s3select_exp_en_t::FATAL);
+    }
+  }
+
+  void set_function_name(const char* name)
+  {
+    m_function_name.assign(name);
+  }
 };
 
 class base_date_extract : public base_function


### PR DESCRIPTION
1. handle cases upon access beyond the bounds of  scratch-area (vector)
2. the user may issue wrong statements that could cause a crash (number of arguments in a function call)