### PR TITLE
handle correctly "anonymous" array/object (defect reported by QE) 

### DIFF
--- a/example/s3select_example.cpp
+++ b/example/s3select_example.cpp
@@ -385,11 +385,14 @@ int process_json_query(const char* input_query,const char* fname)
   std::string buff(BUFFER_SIZE,0);
   std::string result;
 
-  size_t read_sz = input_file_stream.readsome(buff.data(),BUFFER_SIZE);
 
+  size_t read_sz = input_file_stream.read(buff.data(),BUFFER_SIZE).gcount();
+  int chunk_count=0;
+  size_t bytes_read=0;
   while(read_sz)
   {
-    std::cout << "read next chunk " << read_sz << std::endl;
+    bytes_read += read_sz;
+    std::cout << "read next chunk " << chunk_count++ << ":" << read_sz << ":" << bytes_read << "\r";
     result.clear();
 
     try{
@@ -403,7 +406,10 @@ int process_json_query(const char* input_query,const char* fname)
       }
   }
 
-    std::cout << result << std::endl;
+    if(result.size())
+    {
+	std::cout << result << std::endl;
+    }
  
     if(status<0)
     {
@@ -415,7 +421,7 @@ int process_json_query(const char* input_query,const char* fname)
       std::cout << "json processing reached limit " << std::endl;
       break;
     }
-    read_sz = input_file_stream.readsome(buff.data(),BUFFER_SIZE);  
+    read_sz = input_file_stream.read(buff.data(),BUFFER_SIZE).gcount();  
   }
   try{
     	result.clear();
@@ -430,7 +436,6 @@ int process_json_query(const char* input_query,const char* fname)
   }
 
   std::cout << result << std::endl;
-
   return 0;
 }
 
@@ -621,7 +626,7 @@ int run_on_single_query(const char* fname, const char* query)
   std::string buff(BUFFER_SIZE,0);
   while (1)
   {
-    size_t read_sz = input_file_stream.readsome(buff.data(),BUFFER_SIZE);
+    size_t read_sz = input_file_stream.read(buff.data(),BUFFER_SIZE).gcount();
 
     status = awscli->run_s3select(query, buff.data(), read_sz, file_sz);
     if(status<0)

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -2689,6 +2689,9 @@ public:
 
     if(skip_first_line)
     {
+      //the stream may start in the middle of a row (maybe in the middle of a quote).
+      //at this point the stream should skip the first row(broken row).
+      //the csv_parser should be init with the fixed stream position. 
       m_stream += m_skip_x_first_bytes;
       m_skip_x_first_bytes=0;
     }

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -2499,6 +2499,7 @@ private:
   std::string m_last_line;
   size_t m_processed_bytes;
   int64_t m_number_of_tokens;
+  size_t m_skip_x_first_bytes=0;
 
   std::function<int(std::string&)> fp_s3select_result_format=nullptr;
   std::function<int(std::string&)> fp_s3select_header_format=nullptr;
@@ -2651,6 +2652,7 @@ private:
       merge_line = m_last_line + tmp_buff + m_csv_defintion.row_delimiter;
       m_previous_line = false;
       m_skip_first_line = true;
+      m_skip_x_first_bytes = tmp_buff.size()+1;
 
       //processing the merged row (previous broken row)
       run_s3select_on_object(result, merge_line.c_str(), merge_line.length(), false, false, false);
@@ -2685,6 +2687,12 @@ public:
     m_is_to_aggregate = do_aggregate;
     m_skip_last_line = skip_last_line;
 
+    if(skip_first_line)
+    {
+      m_stream += m_skip_x_first_bytes;
+      m_skip_x_first_bytes=0;
+    }
+
     CSVParser _csv_parser("csv", m_stream, m_end_stream);
     csv_parser = &_csv_parser;
     csv_parser->set_csv_def(	m_csv_defintion.row_delimiter, 
@@ -2700,12 +2708,6 @@ public:
     {
       extract_csv_header_info();
     }
-
-    if(skip_first_line)
-    {
-      csv_parser->next_line();
-    }
-
     do
     {
       m_sql_processing_status = Status::INITIAL_STAT;

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -235,7 +235,8 @@ enum class s3select_func_En_t {ADD,
                                LEADING,
                                TRAILING,
                                DECIMAL_OPERATOR,
-                               CAST_TO_DECIMAL
+                               CAST_TO_DECIMAL,
+			       ENGINE_VERSION
                               };
 
 
@@ -306,7 +307,8 @@ private:
     {"#leading#", s3select_func_En_t::LEADING},
     {"#trailing#", s3select_func_En_t::TRAILING},
     {"#decimal_operator#", s3select_func_En_t::DECIMAL_OPERATOR},
-    {"#cast_as_decimal#", s3select_func_En_t::CAST_TO_DECIMAL}
+    {"#cast_as_decimal#", s3select_func_En_t::CAST_TO_DECIMAL},
+    {"engine_version", s3select_func_En_t::ENGINE_VERSION}
 
   };
 
@@ -2191,6 +2193,32 @@ struct _fn_decimal_operator : public base_function {
   }
 };
 
+struct _fn_engine_version : public base_function {
+
+  const char* version_description =R"(PR #137 : 
+the change handle the use cases where the JSON input starts with an anonymous array/object this may cause wrong search result per the user request(SQL statement) 
+
+handle the use-case where the user requests a json-key-path that may point to a non-discrete value. i.e. array or an object. 
+editorial changes.
+
+fix for CSV flow, in the case of a "broken row" (upon processing stream of data) 
+
+null results upon aggregation functions on an empty group (no match for where clause).
+)";
+
+
+  _fn_engine_version()
+  {
+    aggregate = true;
+  }
+
+  bool operator()(bs_stmt_vec_t* args, variable* result) override
+  {
+    result->set_value(version_description);
+    return true;
+  }
+};
+
 base_function* s3select_functions::create(std::string_view fn_name,const bs_stmt_vec_t &arguments)
 {
   const FunctionLibrary::const_iterator iter = m_functions_library.find(fn_name.data());
@@ -2426,6 +2454,10 @@ base_function* s3select_functions::create(std::string_view fn_name,const bs_stmt
 
   case  s3select_func_En_t::CAST_TO_DECIMAL:
     return S3SELECT_NEW(this,_fn_cast_to_decimal);
+    break;
+
+  case  s3select_func_En_t::ENGINE_VERSION:
+    return S3SELECT_NEW(this,_fn_engine_version);
     break;
 
   default:

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -517,9 +517,10 @@ struct _fn_sum : public base_function
 
   value sum;
 
-  _fn_sum() : sum(0)
+  _fn_sum()
   {
     aggregate = true;
+    sum.setnull();
   }
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
@@ -531,6 +532,10 @@ struct _fn_sum : public base_function
 
     try
     {
+      if(sum.is_null())
+      {
+	sum = 0;
+      }
       sum = sum + x->eval();
     }
     catch (base_s3select_exception& e)
@@ -618,7 +623,9 @@ struct _fn_avg : public base_function
     void get_aggregate_result(variable *result) override
     {
         if(count == static_cast<value>(0)) {
-            throw base_s3select_exception("count cannot be zero!");
+            value v_null;
+	    v_null.setnull();
+            *result=v_null;
         } else {
             *result = sum/count ;
         }
@@ -630,9 +637,10 @@ struct _fn_min : public base_function
 
   value min;
 
-  _fn_min():min(__INT64_MAX__)
+  _fn_min()
   {
     aggregate=true;
+    min.setnull();
   }
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
@@ -642,7 +650,7 @@ struct _fn_min : public base_function
     auto iter = args->begin();
     base_statement* x =  *iter;
 
-    if(min > x->eval())
+    if(min.is_null() || min > x->eval())
     {
       min=x->eval();
     }
@@ -662,9 +670,10 @@ struct _fn_max : public base_function
 
   value max;
 
-  _fn_max():max(-__INT64_MAX__)
+  _fn_max()
   {
     aggregate=true;
+    max.setnull();
   }
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
@@ -674,7 +683,7 @@ struct _fn_max : public base_function
     auto iter = args->begin();
     base_statement* x =  *iter;
 
-    if(max < x->eval())
+    if(max.is_null() || max < x->eval())
     {
       max=x->eval();
     }
@@ -694,7 +703,7 @@ struct _fn_to_int : public base_function
   value var_result;
 
   bool operator()(bs_stmt_vec_t* args, variable* result) override
-  {
+  { 
     check_args_size(args,1);
 
     value v = (*args->begin())->eval();

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3318,14 +3318,12 @@ std::string input_json_data = R"(
 }
 )";
 
-#if 0
-  //TODO error phoneNumbers[12][2][2] = null, to check what happen upon reaching the final state
-  expected_result=R"(post 3D
+  expected_result=R"(null
 )";
+  //phoneNumbers[12][2][2] is not a discrete value, should return null
   input_query = "select _1.phoneNumbers[12][2][2] from s3object[*];";
   run_json_query(input_query.c_str(), input_json_data, result);
   ASSERT_EQ(result,expected_result);
-#endif 
 
   //the following tests ia about accessing multi-dimension array
   expected_result=R"(55

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3352,4 +3352,34 @@ std::string input_json_data = R"(
   input_query = "select _1.phoneNumbers[11] from s3object[*];";
   run_json_query(input_query.c_str(), input_json_data, result);
   ASSERT_EQ(result,expected_result);
+
+input_json_data = R"(
+[
+  {
+    "authors": [
+      {
+        "id": 2312688602
+      },
+      {
+        "id": 123
+      }
+    ],
+    "wrong" : {"id" : "it-is-wrong"}
+  }
+]
+)";
+
+  expected_result=R"(2312688602
+)";
+  input_query = "select _1.authors[0].id from s3object[*];";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
+  expected_result=R"(123
+)";
+  input_query = "select _1.authors[1].id from s3object[*];";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
+
  }

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -988,8 +988,8 @@ TEST(TestS3selectFunctions, avgzero)
         false, // dont skip last line
         true   // aggregate call
         ); 
-    ASSERT_EQ(status, -1);
-    ASSERT_EQ(s3select_result, std::string(""));
+    ASSERT_EQ(status, 0);
+    ASSERT_EQ(s3select_result, std::string("null"));
 }
 
 TEST(TestS3selectFunctions, floatavg)

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -734,6 +734,69 @@ TEST(TestS3selectFunctions, count)
   ASSERT_EQ(s3select_result_1,"128"); 
 }
 
+TEST(TestS3selectFunctions, no_args)
+{//note: engine throw an exception(and description), currently it is not catch in this test-app
+#if 0
+  std::string input;
+  size_t size = 128;
+  generate_columns_csv(input, size);
+  std::string input_query_1 = "select min() from stdin;";
+
+  std::string s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,""); 
+
+  input_query_1 = "select max() from stdin;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,""); 
+
+  input_query_1 = "select avg() from stdin;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,""); 
+
+  input_query_1 = "select sum() from stdin;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,""); 
+#endif
+}
+
+TEST(TestS3selectFunctions, empty_group_upon_aggtegation)
+{
+
+  std::string input;
+  size_t size = 128;
+  generate_columns_csv(input, size);
+  std::string input_query_1 = "select min(cast(_1 as int)) from stdin where 1 = 0;";
+
+  std::string s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,"null"); 
+
+  input_query_1 = "select max(cast(_1 as int)) from stdin where 1 = 0;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,"null"); 
+
+  input_query_1 = "select sum(cast(_1 as int)) from stdin where 1 = 0;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,"null"); 
+
+  input_query_1 = "select avg(cast(_1 as int)) from stdin where 1 = 0;";
+
+  s3select_result_1 = run_s3select(input_query_1,input);
+
+  ASSERT_EQ(s3select_result_1,"null"); 
+}
+
 TEST(TestS3selectFunctions, min)
 {
   std::string input;


### PR DESCRIPTION
- the change handle the use cases where the JSON input starts with an anonymous array/object this may cause wrong search result per the user request(SQL statement)

- handle the use-case where the user requests a json-key-path that may point to a non-discrete value. i.e. array or an object.
editorial changes.

- fix for CSV flow, in the case of a "broken row" (upon processing stream of data)

- null results upon aggregation functions on an empty group (no match for where clause).
