### PR TITLE
setup the container definitions according the user cluster definitions

### DIFF
--- a/container/trino/hms_trino.yaml
+++ b/container/trino/hms_trino.yaml
@@ -4,9 +4,10 @@ services:
     image: galsl/hms:dev
     container_name: hms
     environment:
-      # S3_ENDPOINT the CEPH/RGW end-point 
-      #- S3_ENDPOINT=172.21.48.86
-      - S3_ENDPOINT=10.35.4.88
+      # S3_ENDPOINT the CEPH/RGW end-point-url 
+      - S3_ENDPOINT=http://10.0.209.201:80
+      - S3_ACCESS_KEY=abc1
+      - S3_SECRET_KEY=abc1
     # the container starts with booting the hive metastore
     command: sh -c '. ~/.bashrc; start_hive_metastore'
     ports:

--- a/container/trino/trino/catalog/hive.properties
+++ b/container/trino/trino/catalog/hive.properties
@@ -11,13 +11,16 @@ hive.allow-rename-column=true
 
 hive.non-managed-table-writes-enabled=true
 hive.s3select-pushdown.enabled=true
-hive.s3.aws-access-key=b2345678901234567890
-hive.s3.aws-secret-key=b234567890123456789012345678901234567890
+hive.s3.aws-access-key=abc1
+hive.s3.aws-secret-key=abc1
 
 # should modify per s3-endpoint-url
-hive.s3.endpoint=http://172.17.0.1:8000
-#hive.s3.endpoint=10.35.206.20
-#hive.s3.endpoint=172.21.48.86
+hive.s3.endpoint=http://10.0.209.201:80
+
+
+
+
+
 
 
 


### PR DESCRIPTION
user should set the environment variables S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY before boot the trino containers

the bash functions modify the hms_trino.yaml, hive.properties, and the hive-metastore configuration. 
the hive-metastore configuration is modified upon the hms-container is starting.