### PR TITLE
s3select: fix for cast null operation

### DIFF
--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -769,6 +769,10 @@ struct _fn_to_int : public base_function
       var_result = static_cast<int64_t>(v.dbl());
       break;
 
+    case value::value_En_t::S3NULL:
+      var_result.setnull();
+      break;
+
     default:
       var_result = v.i64();
       break;
@@ -813,6 +817,10 @@ struct _fn_to_float : public base_function
 
     case value::value_En_t::FLOAT:
       var_result = v.dbl();
+      break;
+
+    case value::value_En_t::S3NULL:
+      var_result.setnull();
       break;
 
     default:
@@ -2049,6 +2057,11 @@ struct _fn_to_bool : public base_function
     else if (func_arg.type == value::value_En_t::DECIMAL || func_arg.type == value::value_En_t::BOOL)
     {
       i = func_arg.i64();
+    }
+    else if (func_arg.type == value::value_En_t::S3NULL)
+    {
+      result->set_null();
+      return true;
     }
     else
     {

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -1733,6 +1733,7 @@ TEST(TestS3selectFunctions, boolcast)
   test_single_column_single_row("select cast(0 as bool) from s3object;","false\n");
   test_single_column_single_row("select cast(true as bool) from s3object;","true\n");
   test_single_column_single_row("select cast('a' as bool) from s3object;","false\n");
+  test_single_column_single_row("select cast(null as bool) from s3object;","null\n");
 }
 
 TEST(TestS3selectFunctions, floatcast)
@@ -1740,6 +1741,7 @@ TEST(TestS3selectFunctions, floatcast)
   test_single_column_single_row("select cast('1234a' as float) from s3object;","#failure#","extra characters after the number");
   test_single_column_single_row("select cast('a1234' as float) from s3object;","#failure#","text cannot be converted to a number");
   test_single_column_single_row("select cast('999e+999' as float) from s3object;","#failure#","converted value would fall out of the range of the result type!");
+  test_single_column_single_row("select cast(null as float) from s3object;","null\n");
 }
 
 TEST(TestS3selectFunctions, intcast)
@@ -1748,6 +1750,7 @@ TEST(TestS3selectFunctions, intcast)
   test_single_column_single_row("select cast('a1234' as int) from s3object;","#failure#","text cannot be converted to a number");
   test_single_column_single_row("select cast('9223372036854775808' as int) from s3object;","#failure#","converted value would fall out of the range of the result type!");
   test_single_column_single_row("select cast('-9223372036854775809' as int) from s3object;","#failure#","converted value would fall out of the range of the result type!");
+  test_single_column_single_row("select cast(null as int) from s3object;","null\n");
 }
 
 TEST(TestS3selectFunctions, predicate_as_projection_column)


### PR DESCRIPTION
cast null operations were returning false instead of null. This fix resolves the issue.