### PR TITLE
wrong evaluation of logical-operand 

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -1293,11 +1293,11 @@ void push_logical_operator::builder(s3select* self, const char* a, const char* b
   std::string token(a, b);
   logical_operand::oplog_t l = logical_operand::oplog_t::NA;
 
-  if (token == "and")
+  if (boost::iequals(token,"and"))
   {
     l = logical_operand::oplog_t::AND;
   }
-  else if (token == "or")
+  else if (boost::iequals(token,"or")) 
   {
     l = logical_operand::oplog_t::OR;
   }


### PR DESCRIPTION
upon logical_operand(and/or) the parser-builder does not use case-insensitive compare function, resulting in wrong evaluation