### PR TITLE
s3select: replace malformed string(0)

### DIFF
--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -505,7 +505,7 @@ public:
 
   std::string  print(int ident) override
   {
-    return std::string(0);
+    return std::string{};
   }
 
   void push_argument(base_statement* arg)


### PR DESCRIPTION
Fixing a compilation error.
C++23 does not allow int-to-string conversions.