### PR TITLE
crash upon incomplete AST creation

### DIFF
--- a/include/s3select.h
+++ b/include/s3select.h
@@ -1394,7 +1394,8 @@ void push_negation::builder(s3select* self, const char* a, const char* b) const
     logical_operand* f = S3SELECT_NEW(self, logical_operand, pred);
     self->getAction()->exprQ.push_back(f);
   }
-  else if (dynamic_cast<__function*>(pred) || dynamic_cast<negate_function_operation*>(pred) || dynamic_cast<variable*>(pred))
+  else if (dynamic_cast<__function*>(pred) || dynamic_cast<negate_function_operation*>(pred) || dynamic_cast<variable*>(pred) 
+	  || dynamic_cast<addsub_operation*>(pred) || dynamic_cast<mulldiv_operation*>(pred))
   {
     negate_function_operation* nf = S3SELECT_NEW(self, negate_function_operation, pred);
     self->getAction()->exprQ.push_back(nf);

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3073,6 +3073,12 @@ TEST(TestS3selectFunctions, csv_chunk_processing)
 	 ASSERT_EQ(result_aggr,input_object);
 }
 
+TEST(TestS3selectFunctions, not_on_addition_multiplication)
+{
+  test_single_column_single_row("select not (1 + '2') from s3object;","#failure#","illegal binary operation with string");
+  test_single_column_single_row("select not (167 * '8882') from s3object;","#failure#","illegal binary operation with string");
+}
+
 // JSON tests
 
 TEST(TestS3selectFunctions, json_queries)


### PR DESCRIPTION
-- the negation-operation may cause a wrong-build of the AST, that later may cause a crash.
that operation is missing handling of several operators
-- the crash happened upon calling more than once the `parse_query`, the second call accessed an incomplete object in the AST.

the engine should verify the `parse_query` is done once (the current safety-check do not work for all cases)
the `semantic` may cause a crash upon incomplete AST (exception during the syntax parsing)

the crash happened on RGW upon Parquet flow, since that flow has double call to `parse_query`
Queries
"select  not ( '1' + 2 ) from s3object;"
"select  not ( 20 * 30 ) from s3object;"



