### PR TITLE
wrong JSON key classification 

### DIFF
--- a/example/s3select_example.cpp
+++ b/example/s3select_example.cpp
@@ -402,12 +402,16 @@ int process_json_query(const char* input_query,const char* fname)
 
 
   size_t read_sz = input_file_stream.read(buff.data(),BUFFER_SIZE).gcount();
+#ifdef DEBUG_CHUNK_READ
   int chunk_count=0;
+#endif
   size_t bytes_read=0;
   while(read_sz)
   {
     bytes_read += read_sz;
+#ifdef DEBUG_CHUNK_READ
     std::cout << "read next chunk " << chunk_count++ << ":" << read_sz << ":" << bytes_read << "\r";
+#endif
 
     result.clear();
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -789,7 +789,7 @@ public:
 
       json_s3_object = ((S3SELECT_KW(JSON_ROOT_OBJECT)) >> *(bsc::str_p(".") >> json_path_element))[BOOST_BIND_ACTION(push_json_from_clause)];
 
-      json_path_element = bsc::lexeme_d[+( bsc::alnum_p | bsc::str_p("_")) ];
+      json_path_element = bsc::lexeme_d[+( bsc::alnum_p | bsc::str_p("_") | bsc::str_p("*")) ];
 
       object_path = "/" >> *( fs_type >> "/") >> fs_type;
 
@@ -3336,6 +3336,17 @@ private:
 
   int push_key_value_into_scratch_area_per_star_operation(s3selectEngine::scratch_area::json_key_value_t& key_value)
   {
+    //TODO this is wrong , equal keys should override each other. i.e. the later key defines the value.
+    // the input below with 'select * from s3object[*];' will keep push new keys, even upon identical keys
+    // pushing with key-path will avoid that (push "endless" identical keys).
+    // there could be a use case where the keys are unique and star-operation must retrieve a huge line
+    // for this we should define a limitation(number of unique keys per a single retrieved row).
+    // { "root" : [
+    //{ "c1":"815", "c2":"113" },
+    //{ "c1":"256", "c2":"342" }
+    //]
+    //}
+
     m_sa->get_star_operation_cont()->push_back( key_value );
     return 0;
   }

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -3225,10 +3225,6 @@ public:
       f_push_key_value_into_scratch_area_per_star_operation = [this](s3selectEngine::scratch_area::json_key_value_t& key_value)
                 {return push_key_value_into_scratch_area_per_star_operation(key_value);};
 
-    //setting the container for all json-variables, to be extracted by the json reader    
-    JsonHandler.set_statement_json_variables(query->get_json_variables_access());
-
-
     //calling to getMatchRow. processing a single row per each call.
     JsonHandler.set_s3select_processing_callback(f_sql);
     //upon excat match between input-json-key-path and sql-statement-variable-path the callback pushes to scratch area 
@@ -3270,6 +3266,9 @@ public:
     }
 
     m_sa->set_parquet_type();//TODO json type
+
+    //setting the container for all json-variables, to be extracted by the json reader    
+    JsonHandler.set_statement_json_variables(query->get_json_variables_access());
   }
     
   json_object(s3select* query):base_s3object(query),m_processed_bytes(0),m_end_of_stream(false),m_row_count(0),star_operation_ind(false),m_init_json_processor_ind(false)

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -3336,18 +3336,10 @@ private:
 
   int push_key_value_into_scratch_area_per_star_operation(s3selectEngine::scratch_area::json_key_value_t& key_value)
   {
-    //TODO this is wrong , equal keys should override each other. i.e. the later key defines the value.
-    // the input below with 'select * from s3object[*];' will keep push new keys, even upon identical keys
-    // pushing with key-path will avoid that (push "endless" identical keys).
-    // there could be a use case where the keys are unique and star-operation must retrieve a huge line
-    // for this we should define a limitation(number of unique keys per a single retrieved row).
-    // { "root" : [
-    //{ "c1":"815", "c2":"113" },
-    //{ "c1":"256", "c2":"342" }
-    //]
-    //}
-
-    m_sa->get_star_operation_cont()->push_back( key_value );
+    //upon star-operation on nested JSON, there could be many keys in a single row (actually, there is no limitation).
+    //for many cases these keys are duplicated in the scope of a single-row (row is defined according to SQL statement).
+    //the following routine saves only unique keys.
+    m_sa->json_push_key_value_per_star_operation(key_value);
     return 0;
   }
 

--- a/include/s3select.h
+++ b/include/s3select.h
@@ -795,7 +795,7 @@ public:
 
       json_s3_object = ((S3SELECT_KW(JSON_ROOT_OBJECT)) >> *(bsc::str_p(".") >> json_path_element))[BOOST_BIND_ACTION(push_json_from_clause)];
 
-      json_path_element = bsc::lexeme_d[+( bsc::alnum_p | bsc::str_p("_") | bsc::str_p("*") | (string))][BOOST_BIND_ACTION(push_json_from_clause_key_path)];
+      json_path_element = (bsc::lexeme_d[+( bsc::alnum_p | bsc::str_p("_") ) ] | bsc::str_p("*") | (string))[BOOST_BIND_ACTION(push_json_from_clause_key_path)];
 
       object_path = "/" >> *( fs_type >> "/") >> fs_type;
 

--- a/include/s3select_functions.h
+++ b/include/s3select_functions.h
@@ -2268,6 +2268,17 @@ the whole system resides in a container [ docker pull galsl/fedora_38:tpcds_v2 ]
 -- avoid timeout upon long processing #152
 -- replace assert with an exception to avoid crashing the process #151
 -- fix for the use-case of not-operator on a string #153
+
+-- the negation-operation may cause a wrong-build of the AST, that later may cause a crash. that operation is missing handling of several operators. #160
+-- the crash happened upon calling more than once the parse_query, the second call accessed an incomplete object in the AST. #160
+
+-- fix for identifies key-value as key-object or key-array #161
+-- wrong initialization of the JSON parser engine had caused missing a projection-key-path upon using different combinations of the from-clause path. #161
+-- a fix for copy-constructor, upon a JSON value is an empty string, it causes a wrong result. #161
+-- modification for JSON star operation, the new-type container saves only unique keys, to avoid high memory consumption. #161
+-- the from-clause can handle a wild-card. i.e. upon wild-card(*) it skips the corresponding part in projection-key-path. #161
+-- key-path may include meta-char(like a dot) select _1."i.e."[0] the "i.e." is part of the key-path. #161
+
 )";
 
   _fn_engine_version()

--- a/include/s3select_json_parser.h
+++ b/include/s3select_json_parser.h
@@ -640,12 +640,6 @@ class JsonParserHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 	m_current_depth_non_anonymous++;
       } 
 
-#if 0
-      if(from_clause.size() == 0 || std::equal(key_path.begin(), key_path.end(), from_clause.begin(), from_clause.end(), iequal_predicate)) {
-        prefix_match = true;
-      }
-#endif
-
       variable_match_operations.key();
 
       return true;
@@ -654,9 +648,7 @@ class JsonParserHandler : public rapidjson::BaseReaderHandler<rapidjson::UTF8<>,
 
     void set_prefix_match(){
       if(from_clause.size() == 0 || std::equal(key_path.begin(), key_path.end(), from_clause.begin(), from_clause.end(), iequal_predicate)) {
-	std::cout << "prefix_match = true :" << get_key_path() << std::endl;
-        prefix_match = true; //TODO it is not prefix in the case its a key/value . it is a prefix match in case it is key for array of key for object
-	//start-array , start-object can set the prefix match (from-clause match)
+        prefix_match = true; //it is not prefix_match in the case its a key/value . it is a prefix match in the case it is a key of array or key of an object
       }
     }
 

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -594,7 +594,7 @@ public:
 
   void set_json_key_path(std::vector<std::string>& key_path)
   {
-    m_json_key = key_path;
+    m_json_key = key_path;//TODO not efficient 
   }
 
   const char* to_string()  //TODO very intensive , must improve this
@@ -693,9 +693,10 @@ public:
 	m_str_value = o.m_str_value;
 	__val.str = m_str_value.data();
       }
-      else if(o.__val.str)
+      else if(o.__val.str)//it is done upon using the set_string_nocopy 
       {
-	__val.str = o.__val.str;
+	m_str_value.assign(o.__val.str);//need to create a copy for this
+	__val.str = m_str_value.data();
       }
     }
     else
@@ -717,9 +718,10 @@ public:
 	m_str_value = o.m_str_value;
 	__val.str = m_str_value.data();
       }
-      else if(o.__val.str)
+      else if(o.__val.str)//it is done upon using the set_string_nocopy
       {
-	__val.str = o.__val.str;
+	m_str_value.assign(o.__val.str);
+	__val.str = m_str_value.data();
       }
     }
     else
@@ -1857,8 +1859,8 @@ public:
     else
     {
       m_scratch->get_column_value(column_pos,var_value);
-      //in the case of successive column-delimiter {1,some_data,,3}=> third column is NULL 
-      if (var_value.is_string() && (var_value.str()== 0 || (var_value.str() && *var_value.str()==0))){
+      //in the case of successive column-delimiter {1,some_data,,3}=> third column is NULL(CSV data source)
+      if (!is_json_statement() && var_value.is_string() && (var_value.str()== 0 || (var_value.str() && *var_value.str()==0))){
           var_value.setnull();//TODO is it correct for Parquet
       }
     }

--- a/include/s3select_oper.h
+++ b/include/s3select_oper.h
@@ -1157,7 +1157,7 @@ private:
 public:
 
   typedef std::pair<std::vector<std::string>,value> json_key_value_t;
-  typedef std::vector< json_key_value_t > json_star_op_cont_t;
+  typedef std::vector< json_key_value_t > json_star_op_cont_t;//TODO should use a std::map(unique-keys)
   json_star_op_cont_t m_json_star_operation;
 
   scratch_area():m_upper_bound(-1),parquet_type(false),buff_loc(0),max_json_idx(-1)

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3557,6 +3557,80 @@ std::string input_json_data = R"(
 
 }
 
+TEST(TestS3selectFunctions, json_keys_containing_meta_char)
+{
+//purpose: keys may contain meta-char such as dot{.} or comma,white-space, etc.
+//the syntax parser should process correctly queries containing access to keys with meta-char's.
+//keys of objects or arrays.
+
+std::string input_json_data = R"(
+{
+  "root": {
+    "hello": "world",
+    "t": "true",
+    "f": "false",
+    "n": "null",
+    "i": 123,
+    "pi": 3.1416,
+    "nested object": {
+      "hello2": "world",
+      "t2": true,
+      "nested2": {
+        "c1": "c1_value",
+        "array.nested2": [
+          10,
+          20,
+          30,
+          40
+        ],
+        "c2": "c2_valuec2_value"
+      },
+      "nested3": {
+        "hello3": "world",
+        "t2": true,
+        "nested4": {
+          "c1": "c1_value",
+          "array_nested3": [
+            100,
+            200,
+            300,
+            400
+          ]
+        }
+      }
+    },
+    "array_1": [
+      1,
+      2,
+      3,
+      4
+    ]
+  }
+}
+)";
+
+  std::string result;
+  std::string expected_result;
+  std::string input_query;
+
+  expected_result=R"(100
+)";
+
+  //the query access a key containing white-space
+  input_query = "select _1.root.\"nested object\".nested3.nested4.array_nested3[0] from s3object[*];";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
+  expected_result=R"(30
+)";
+
+  //the query access a key containing 2 parts that contains meta-chars
+  input_query = "select _1.root.\"nested object\".nested2.\"array.nested2\"[2]  from s3object[*];";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
+}
+
  TEST(TestS3selectFunctions, json_queries_format)
 {
   std::string result;

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3638,6 +3638,14 @@ std::string input_json_data = R"(
   run_json_query(input_query.c_str(), input_json_data, result);
   ASSERT_EQ(result,expected_result);
 
+  expected_result=R"(1234
+)";
+
+  //the query has a key access combintion of prjection and from-clause, both parts (projection and from-clause) contains meta-chars
+  input_query = R"(select _1.nested2."total hits" from s3object[*].root."nested object";)";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
 }
 
  TEST(TestS3selectFunctions, json_queries_format)

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3186,53 +3186,21 @@ null,null,null
   run_json_query(input_query, json_input,result);
   ASSERT_EQ(result,expected_result);
 
-  expected_result=R"(firstName. : Joe
-lastName. : Jackson
-gender. : male
-age. : twenty
-address.streetAddress. : 101
-address.city. : San Diego
-address.state. : CA
-firstName. : Joe_2
-lastName. : Jackson_2
-gender. : male
-age. : 21
-address.streetAddress. : 101
-address.city. : San Diego
-address.state. : CA
-phoneNumbers.type. : home1
+
+
+  expected_result=R"(description.main_desc. : value_1
 phoneNumbers.number. : 734928_1
-phoneNumbers.addr. : 11
-phoneNumbers.type. : home2
-phoneNumbers.number. : 734928_2
-phoneNumbers.addr. : 22
-phoneNumbers.type. : home3
-phoneNumbers.number. : 734928_3
-phoneNumbers.addr. : 33
-phoneNumbers.type. : home4
-phoneNumbers.number. : 734928_4
-phoneNumbers.addr. : 44
-phoneNumbers.type. : home5
-phoneNumbers.number. : 734928_5
-phoneNumbers.addr. : 55
-phoneNumbers.type. : home6
-phoneNumbers.number. : 734928_6
-phoneNumbers.addr. : 66
-phoneNumbers.type. : home7
-phoneNumbers.number. : 734928_7
-phoneNumbers.addr. : 77
-phoneNumbers.type. : home8
-phoneNumbers.number. : 734928_8
-phoneNumbers.addr. : 88
-phoneNumbers.type. : home9
-phoneNumbers.number. : 734928_9
-phoneNumbers.addr. : 99
-phoneNumbers.type. : home10
-phoneNumbers.number. : 734928_10
-phoneNumbers.addr. : 100
-key_after_array. : XXX
-description.main_desc. : value_1
+phoneNumbers.type. : home1
+address.state. : CA
 description.second_desc. : value_2
+address.streetAddress. : 101
+phoneNumbers.addr. : 11
+address.city. : San Diego
+age. : twenty
+gender. : male
+key_after_array. : XXX
+lastName. : Jackson
+firstName. : Joe
 #=== 0 ===#
 )";
 
@@ -3241,35 +3209,36 @@ description.second_desc. : value_2
   run_json_query(input_query, json_input,result);
   ASSERT_EQ(result,expected_result);
 
-  expected_result=R"(phoneNumbers.type. : home2
+expected_result=R"(phoneNumbers.addr. : 22
 phoneNumbers.number. : 734928_2
-phoneNumbers.addr. : 22
+phoneNumbers.type. : home2
 #=== 0 ===#
-phoneNumbers.type. : home3
-phoneNumbers.number. : 734928_3
 phoneNumbers.addr. : 33
+phoneNumbers.number. : 734928_3
+phoneNumbers.type. : home3
 #=== 1 ===#
-phoneNumbers.type. : home4
-phoneNumbers.number. : 734928_4
 phoneNumbers.addr. : 44
+phoneNumbers.number. : 734928_4
+phoneNumbers.type. : home4
 #=== 2 ===#
-phoneNumbers.type. : home5
-phoneNumbers.number. : 734928_5
 phoneNumbers.addr. : 55
+phoneNumbers.number. : 734928_5
+phoneNumbers.type. : home5
 #=== 3 ===#
-phoneNumbers.type. : home6
-phoneNumbers.number. : 734928_6
 phoneNumbers.addr. : 66
+phoneNumbers.number. : 734928_6
+phoneNumbers.type. : home6
 #=== 4 ===#
-phoneNumbers.type. : home7
-phoneNumbers.number. : 734928_7
 phoneNumbers.addr. : 77
+phoneNumbers.number. : 734928_7
+phoneNumbers.type. : home7
 #=== 5 ===#
-phoneNumbers.type. : home8
-phoneNumbers.number. : 734928_8
 phoneNumbers.addr. : 88
+phoneNumbers.number. : 734928_8
+phoneNumbers.type. : home8
 #=== 6 ===#
 )";
+
 
   // star-operation on object, from-clause points on array, with where-clause
   input_query = "select * from s3object[*].phonenumbers where _1.addr between 20 and 89;";

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3596,13 +3596,24 @@ std::string input_json_data = R"(
 
 std::string input_json_data = R"(
   {"root" : [
-  {"c1": 891,"c2": 903,"c3": 78,"c4": 566,"c5": 134,"c6": 121,"c7": 203,"c8": 795,"c9": 82,"c10": 135},
-  {"c1": 218,"c2": 881,"c3": 840,"c4": 385,"c5": 385,"c6": 674,"c7": 618,"c8": 99,"c9": 296,"c10": 545},
-  {"c1": 218,"c2": 881,"c3": 840,"c4": 385,"c5": 385,"c6": 674,"c7": 618,"c8": 99,"c9": 296,"c10": 545}
+  {"c1": 891,"c2": 903,"c3": 78,"c4": 566,"c5": 134,"c6": 121,"c7": 203,"c8": 795,"c9": "82","c10": 135},
+  {"c1": 218,"c2": 881,"c3": 840,"c4": 385,"c5": 385,"c6": 674,"c7": 618,"c8": 99,"c9": "","c10": 545},
+  {"c1": 218,"c2": 881,"c3": 840,"c4": 385,"c5": 385,"c6": 674,"c7": 618,"c8": 99,"c9": "296","c10": 545}
   ]
   }
   )";
-  
+ 
+
+  //purpose: upon empty string values, the empty value not override by other values. 
+  expected_result=R"({"c9":82}
+{"c9":}
+{"c9":296}
+)";
+  input_query = "select _1.c9 from s3object[*].root;";
+
+  run_json_query(input_query.c_str(), input_json_data, result, true);
+  ASSERT_EQ(result,expected_result);
+
   expected_result=R"({"_1":1327}
 )";
   input_query = "select sum(_1.c1) from s3object[*].root;";

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3578,6 +3578,13 @@ std::string input_json_data = R"(
   input_query = "select _1.c1 from s3object[*].root.nested_obj.nested2;";
   run_json_query(input_query.c_str(), input_json_data, result);
   ASSERT_EQ(result,expected_result);
+  
+  //the wildcard in from-clause means to skip a path-part(consider equal to projection counter part)
+  expected_result=R"(c1_value
+)";
+  input_query = "select _1.c1 from s3object[*].*.nested_obj.*.nested4;";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
 
 }
 

--- a/test/s3select_test.cpp
+++ b/test/s3select_test.cpp
@@ -3583,7 +3583,8 @@ std::string input_json_data = R"(
           30,
           40
         ],
-        "c2": "c2_valuec2_value"
+        "c2": "c2_valuec2_value",
+	"total hits": 1234
       },
       "nested3": {
         "hello3": "world",
@@ -3624,8 +3625,16 @@ std::string input_json_data = R"(
   expected_result=R"(30
 )";
 
-  //the query access a key containing 2 parts that contains meta-chars
-  input_query = "select _1.root.\"nested object\".nested2.\"array.nested2\"[2]  from s3object[*];";
+  //the query access a key containing 2 parts each contains meta-chars
+  input_query = "select _1.root.\"nested object\".nested2.\"array.nested2\"[2] from s3object[*];";
+  run_json_query(input_query.c_str(), input_json_data, result);
+  ASSERT_EQ(result,expected_result);
+
+  expected_result=R"(1234
+)";
+
+  //the query access a key containing 2 parts each contains meta-chars , the "total hits" is key/value
+  input_query = R"(select _1.root."nested object".nested2."total hits" from s3object[*];)";
   run_json_query(input_query.c_str(), input_json_data, result);
   ASSERT_EQ(result,expected_result);
 


### PR DESCRIPTION
-- some JSON processing identifies key-value as key-object or key-array, 
this wrong identification may cause wrong results

-- wrong initialization of the JSON parser engine had caused missing a projection-key-path upon using different combinations of the from-clause path.

-- a fix for copy-constructor, upon a JSON value is an empty string, it causes a wrong result.

-- modification for JSON star operation, the new-type container saves only unique keys, to avoid high memory consumption.

-- the from-clause can handle a wild-card. i.e. upon wild-card(*) it skips the corresponding part in projection-key-path.

-- key-path may include meta-char(like a dot) select _1."i.e."[0] the "i.e." is part of the key-path.
a key-path

TODO :
```
{
  "array": [
    {
      "classname2": [
        {
          "a": "a_value"
        }
      ],
      "classname3": [
        {
          "a": "a_value_classname3"
        }
      ]
    }
  ]
}
```
the following statement returns the wrong result
`select _1.array.classname2.a from s3object[*];`

TODO: from-clause may point on array,  _1 may scan array-values

https://bugzilla.redhat.com/show_bug.cgi?id=2242089
 _[s3select][json]: some of the "from" clause filters with "limit 1" are taking time as if to query the entire object and results are also incorrect_