### PR TITLE
arrow/parquet : limit the parquet-reader memory usage 

### DIFF
--- a/example/s3select_example.cpp
+++ b/example/s3select_example.cpp
@@ -320,8 +320,10 @@ int run_query_on_parquet_file(const char* input_query, const char* input_file)
 	  std::cout << "DEBUG: {" <<  msg << "}" << std::endl;
   };
 
+  std::function<void(const char*)> fp_nop = [](const char* msg){};
+  std::function<int(std::string&)> fp_continue_nop = [](std::string& result){return 0;};
   parquet_object parquet_processor(input_file,&s3select_syntax,&rgw);
-  //parquet_processor.set_external_debug_system(fp_debug);
+  parquet_processor.set_external_system_functions(fp_continue_nop, fp_s3select_result_format, fp_s3select_header_format,fp_nop);
 
   std::string result;
 


### PR DESCRIPTION
using reader-properties to set buffer size upon reading column chunks.
it is useful for very big row-groups(huge number of values per column).

https://bugzilla.redhat.com/show_bug.cgi?id=2252403