### PR TITLE
s3select: fix "redundant move in return statement" warnings

### DIFF
--- a/include/s3select_parquet_intrf.h
+++ b/include/s3select_parquet_intrf.h
@@ -589,7 +589,7 @@ class ReadableFile::ReadableFileImpl : public ObjectInterface {
       RETURN_NOT_OK(buffer->Resize(bytes_read));
       buffer->ZeroPadding();
     }
-    return std::move(buffer);
+    return buffer;
   }
 
   Result<std::shared_ptr<Buffer>> ReadBufferAt(int64_t position, int64_t nbytes) {
@@ -601,7 +601,7 @@ class ReadableFile::ReadableFileImpl : public ObjectInterface {
       RETURN_NOT_OK(buffer->Resize(bytes_read));
       buffer->ZeroPadding();
     }
-    return std::move(buffer);
+    return buffer;
   }
 
   Status WillNeed(const std::vector<ReadRange>& ranges) {


### PR DESCRIPTION
ReadableFile::ReadableFileImpl::ReadBuffer and
ReadableFile::ReadableFileImpl::ReadbufferAt each have a std::move that's not needed and generates a compiler warning.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>
(cherry picked from commit 13d0104ae338dc74cf32dfa447a432e27b826fd1)