### PR TITLE
hive-properties : set the ssl-enbale to false.

### DIFF
--- a/container/trino/trino/catalog/hive.properties
+++ b/container/trino/trino/catalog/hive.properties
@@ -18,8 +18,7 @@ hive.s3.aws-secret-key=abc1
 hive.s3.endpoint=http://10.0.209.201:80
 
 
-
-
+hive.s3.ssl.enabled=false
 
 
 


### PR DESCRIPTION
due to the Trino error message "Query 20241113_145856_00005_2haas failed: Unable to execute HTTP request: Unsupported or unrecognized SSL message"