### PR TITLE
fix clang narrowing conversion error

### DIFF
--- a/include/s3select_parquet_intrf.h
+++ b/include/s3select_parquet_intrf.h
@@ -1065,7 +1065,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
   FileMetaData* file_metadata_;
   std::unique_ptr<RowGroupMetaData> row_group_metadata_;
   ReaderProperties properties_;
-  int row_group_ordinal_;
+  int16_t row_group_ordinal_;
   std::shared_ptr<InternalFileDecryptor> file_decryptor_;
 };
 


### PR DESCRIPTION
Store `row_group_ordinal_` as `int16_t` to match the corresponding `CryptoContext` constructor parameter and avoid a C++11 narrowing conversion error when building with Clang.

```
  src/s3select/include/s3select_parquet_intrf.h:1048:9: error: non-constant-expression cannot be narrowed from type 'int' to 'int16_t' (aka 'short') in initializer list [-Wc++11-narrowing]
   1048 |         row_group_ordinal_,
        |         ^~~~~~~~~~~~~~~~~~
  src/s3select/include/s3select_parquet_intrf.h:1048:9: note: insert an explicit cast to silence this issue
   1048 |         row_group_ordinal_,
        |         ^~~~~~~~~~~~~~~~~~
        |         static_cast<int16_t>( )
```